### PR TITLE
Fix settings modal behavior

### DIFF
--- a/MythForgeUI.html
+++ b/MythForgeUI.html
@@ -260,11 +260,21 @@
 
         function closeSettings(){ settingsModal.style.display='none'; }
 
+        function updateAvatarDisplays(){
+            document.querySelectorAll('.user-avatar').forEach(el=>{
+                el.textContent = (state.settings.userName[0] || 'U');
+            });
+            document.querySelectorAll('.ai-avatar').forEach(el=>{
+                el.textContent = (state.settings.botName[0] || 'A');
+            });
+        }
+
         function saveSettingsFromUI(){
             state.settings.userName = userNameInput.value.trim() || 'You';
             state.settings.botName  = botNameInput.value.trim()  || 'Bot';
             applyTheme(themeSelect.value);
             saveSettings();
+            updateAvatarDisplays();
             closeSettings();
         }
 
@@ -458,7 +468,6 @@
             if(state.currentChatId) await loadChat(state.currentChatId);
             await refreshGlobalPromptList();
             autoResize();
-            openSettings();
         })();
     </script>
 </body>


### PR DESCRIPTION
## Summary
- prevent settings modal from auto opening on page load
- update avatar initials when user saves settings

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68437e5c9ac8832ba28558e29aecaf46