### PR TITLE
Move last prompt toggle to sidebar

### DIFF
--- a/MythForgeUI.html
+++ b/MythForgeUI.html
@@ -166,11 +166,10 @@
             <div class="history-container" id="history-container"></div>
             <button id="open-settings-btn" class="new-chat">Settings</button>
             <button id="delete-chat-btn" class="new-chat" style="margin-top:10px;background-color:rgba(220,53,69,0.8);">Delete Chat</button>
+            <button id="system-toggle" class="new-chat" style="display:none;margin-top:10px;">⚙️ Last Prompt</button>
         </div>
         <div class="main">
-            <div class="top-controls">
-                <span id="system-toggle" style="cursor:pointer;">⚙️ Last Prompt</span>
-            </div>
+            <div class="top-controls"></div>
             <div id="system-container"><pre id="system-prompt" style="white-space:pre-wrap; margin:0;"></pre></div>
             <div class="chat-container" id="chat-container"></div>
             <div class="input-area">
@@ -313,6 +312,7 @@
             renderHistory();
             chatContainer.innerHTML='';
             systemPrompt.textContent='';
+            systemToggle.style.display='none';
             try{
                 const res = await fetch(`${CONFIG.apiUrl}/history/${encodeURIComponent(id)}`);
                 if(!res.ok) return;
@@ -365,6 +365,7 @@
               renderHistory();
               chatContainer.innerHTML = '';
               systemPrompt.textContent = '';
+              systemToggle.style.display = 'none';
         }
 
         async function deleteChat(){
@@ -379,6 +380,7 @@
                 renderHistory();
                 chatContainer.innerHTML = '';
                 systemPrompt.textContent = '';
+                systemToggle.style.display = 'none';
             }catch(err){ console.error('Failed to delete chat:', err); alert('Error deleting chat: '+err.message); }
         }
 
@@ -435,7 +437,11 @@
                             const chunk = buffer.slice(0, idx); buffer = buffer.slice(idx+1);
                             if(firstLine){
                                 firstLine=false;
-                                try{ const meta=JSON.parse(chunk); systemPrompt.textContent=meta.prompt||''; }catch{};
+                                try{
+                                    const meta=JSON.parse(chunk);
+                                    systemPrompt.textContent = meta.prompt || '';
+                                    systemToggle.style.display = meta.prompt ? 'block' : 'none';
+                                }catch{}
                             }else{
                                 accumulated += chunk; aiElement.innerHTML = accumulated.replace(/\n/g,'<br>');
                                 chatContainer.scrollTop = chatContainer.scrollHeight;


### PR DESCRIPTION
## Summary
- move the "Last Prompt" toggle into the sidebar
- hide the toggle until a system prompt is available
- reset toggle visibility whenever chats change

## Testing
- `python -m py_compile MythForgeServer.py`


------
https://chatgpt.com/codex/tasks/task_e_684381ee70a0832b8bf6e49108f9206c