### PR TITLE
Fix UI API URL for remote clients

### DIFF
--- a/MythForgeUI.html
+++ b/MythForgeUI.html
@@ -207,7 +207,7 @@
     </div>
 
     <script>
-        const CONFIG = { apiUrl: 'http://localhost:8000' };
+        const CONFIG = { apiUrl: window.location.origin };
         const state = { chats: [], currentChatId: '', settings:{ userName:'You', botName:'Bot', theme:'light' }, isGenerating: false };
 
         const chatContainer    = document.getElementById('chat-container');


### PR DESCRIPTION
## Summary
- use `window.location.origin` for API base URL so that the UI works when accessed from other devices

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684383b43f84832b99e95160eb8635e6