### PR TITLE
Add PWA manifest for iPad full-screen

### DIFF
--- a/MythForgeUI.html
+++ b/MythForgeUI.html
@@ -3,6 +3,8 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <link rel="manifest" href="manifest.json">
+    <meta name="apple-mobile-web-app-capable" content="yes">
     <title>Myth Forge</title>
     <style>
         /* --- Theme Variables copied from LocalLLMChatv2 --- */

--- a/manifest.json
+++ b/manifest.json
@@ -1,0 +1,6 @@
+{
+  "name": "Myth Forge",
+  "short_name": "MythForge",
+  "display": "standalone",
+  "start_url": "/MythForgeUI.html"
+}


### PR DESCRIPTION
## Summary
- add a minimal web manifest
- reference it in MythForgeUI.html for iOS full-screen mode

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684386052034832ba770ce98e9d05ac5