### PR TITLE
Add tabs for sidebar control

### DIFF
--- a/MythForgeUI.html
+++ b/MythForgeUI.html
@@ -151,24 +151,56 @@
         .input-container { display: flex; width: 100%; max-width: 800px; margin: 0 auto; position: relative; }
         .send-button { position: absolute; right: 8px; bottom: 8px; background: none; border: none; cursor: pointer; color: var(--primary); padding: 5px; border-radius: 4px; }
         #system-container { display:none; padding:10px; background: var(--chat-bg); }
+
+        .tab-bar {
+            width: 40px;
+            background-color: var(--sidebar-bg);
+            color: var(--sidebar-text);
+            display: flex;
+            flex-direction: column;
+            align-items: center;
+            padding-top: 8px;
+        }
+        .tab-bar button {
+            background: none;
+            border: none;
+            color: inherit;
+            cursor: pointer;
+            font-size: 20px;
+            width: 100%;
+            padding: 10px 0;
+        }
+        .tab-bar button.active { background-color: var(--sidebar-btn-hover); }
+        .sidebar.hidden { display: none; }
+        #chat-section, #more-section { flex-grow: 1; display: flex; flex-direction: column; }
+        #more-section { overflow-y: auto; }
     </style>
 </head>
 <body>
     <div class="app-container">
-        <div class="sidebar">
-            <button class="new-chat" id="new-chat-btn">New Chat</button>
-            <div class="sidebar-section">
-                <label for="globalPromptSelect">Global Prompt</label>
-                <select id="globalPromptSelect">
-                    <option value="">(no global prompt)</option>
-                </select>
-                <button id="edit-prompt-btn">Edit Prompt</button>
-                <button id="add-prompt-btn">Add Prompt</button>
+        <div class="tab-bar">
+            <button id="hide-tab" title="Hide">&#8592;</button>
+            <button id="chat-tab" title="Chats">&#128172;</button>
+            <button id="more-tab" title="More">&#9881;</button>
+        </div>
+        <div class="sidebar" id="sidebar">
+            <div id="chat-section">
+                <button class="new-chat" id="new-chat-btn">New Chat</button>
+                <div class="history-container" id="history-container"></div>
             </div>
-            <div class="history-container" id="history-container"></div>
-            <button id="open-settings-btn" class="new-chat">Settings</button>
-            <button id="delete-chat-btn" class="new-chat" style="margin-top:10px;background-color:rgba(220,53,69,0.8);">Delete Chat</button>
-            <button id="system-toggle" class="new-chat" style="display:none;margin-top:10px;">⚙️ Last Prompt</button>
+            <div id="more-section" style="display:none;">
+                <div class="sidebar-section">
+                    <label for="globalPromptSelect">Global Prompt</label>
+                    <select id="globalPromptSelect">
+                        <option value="">(no global prompt)</option>
+                    </select>
+                    <button id="edit-prompt-btn">Edit Prompt</button>
+                    <button id="add-prompt-btn">Add Prompt</button>
+                </div>
+                <button id="open-settings-btn" class="new-chat">Settings</button>
+                <button id="delete-chat-btn" class="new-chat" style="margin-top:10px;background-color:rgba(220,53,69,0.8);">Delete Chat</button>
+                <button id="system-toggle" class="new-chat" style="display:none;margin-top:10px;">⚙️ Last Prompt</button>
+            </div>
         </div>
         <div class="main">
             <div class="top-controls"></div>
@@ -230,6 +262,12 @@
         const settingsSaveBtn  = document.getElementById('settings-save-btn');
         const userNameInput    = document.getElementById('user-name-input');
         const botNameInput     = document.getElementById('bot-name-input');
+        const hideTab          = document.getElementById('hide-tab');
+        const chatTab          = document.getElementById('chat-tab');
+        const moreTab          = document.getElementById('more-tab');
+        const sidebar          = document.getElementById('sidebar');
+        const chatSection      = document.getElementById('chat-section');
+        const moreSection      = document.getElementById('more-section');
 
         function applyTheme(name){
             document.body.setAttribute('data-theme', name);
@@ -280,6 +318,28 @@
         }
 
         function toggleSystem(){ systemContainer.style.display = systemContainer.style.display === 'none' ? 'block':'none'; }
+
+        function showChatTab(){
+            sidebar.classList.remove('hidden');
+            chatSection.style.display = 'flex';
+            moreSection.style.display = 'none';
+            chatTab.classList.add('active');
+            moreTab.classList.remove('active');
+        }
+
+        function showMoreTab(){
+            sidebar.classList.remove('hidden');
+            chatSection.style.display = 'none';
+            moreSection.style.display = 'flex';
+            chatTab.classList.remove('active');
+            moreTab.classList.add('active');
+        }
+
+        function hideSidebar(){
+            sidebar.classList.add('hidden');
+            chatTab.classList.remove('active');
+            moreTab.classList.remove('active');
+        }
 
         function renderHistory(){
             historyContainer.innerHTML = '';
@@ -473,12 +533,16 @@
             editPromptBtn.addEventListener('click', openPromptEditor);
             addPromptBtn.addEventListener('click', addNewPrompt);
             systemToggle.addEventListener('click', toggleSystem);
+            hideTab.addEventListener('click', hideSidebar);
+            chatTab.addEventListener('click', showChatTab);
+            moreTab.addEventListener('click', showMoreTab);
         }
 
         (async function init(){
             loadSettings();
             loadTheme();
             setupEvents();
+            showChatTab();
             await fetchChatList();
             if(state.currentChatId) await loadChat(state.currentChatId);
             await refreshGlobalPromptList();


### PR DESCRIPTION
## Summary
- add vertical tab bar with hide, chat, and more buttons
- move sidebar content into chat and more sections
- implement JS logic to toggle sidebar visibility and sections

## Testing
- `python -m py_compile MythForgeServer.py`

------
https://chatgpt.com/codex/tasks/task_e_68438a129024832b8b3b39d5e7fd1eab