### PR TITLE
Fix UI reposition after keyboard hide on iPad

### DIFF
--- a/MythForgeUI.html
+++ b/MythForgeUI.html
@@ -448,6 +448,11 @@
 
         function autoResize(){ userInput.style.height='auto'; userInput.style.height=Math.min(userInput.scrollHeight,200)+'px'; }
 
+        function scrollToBottom(){
+            chatContainer.scrollTop = chatContainer.scrollHeight;
+            window.scrollTo(0, document.body.scrollHeight);
+        }
+
         function appendMessageToUI(role, content){
             const div=document.createElement('div');
             div.className=`message ${role==='user'?'user-message':'ai-message'}`;
@@ -528,6 +533,7 @@
             sendButton.addEventListener('click', sendMessage);
             userInput.addEventListener('keydown', e=>{ if(e.key==='Enter' && !e.shiftKey){ e.preventDefault(); sendMessage(); } });
             userInput.addEventListener('input', ()=>{ sendButton.disabled = userInput.value.trim()==='' || state.isGenerating; autoResize(); });
+            userInput.addEventListener('blur', ()=>{ setTimeout(scrollToBottom, 100); });
             newChatButton.addEventListener('click', startNewChat);
             deleteChatBtn.addEventListener('click', deleteChat);
             editPromptBtn.addEventListener('click', openPromptEditor);


### PR DESCRIPTION
## Summary
- scroll chat to bottom after iPad keyboard hides

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68438d35dc78832b914b53d062a66405