### PR TITLE
Fix chat scrolling

### DIFF
--- a/MythForgeUI.html
+++ b/MythForgeUI.html
@@ -473,7 +473,8 @@
 
         function scrollToBottom(){
             chatContainer.scrollTop = chatContainer.scrollHeight;
-            window.scrollTo(0, document.body.scrollHeight);
+            const lastMsg = chatContainer.lastElementChild;
+            if(lastMsg) lastMsg.scrollIntoView({block:'end'});
         }
 
         function appendMessageToUI(role, content){


### PR DESCRIPTION
## Summary
- ensure last message scrolls into view after appending

## Testing
- `python -m py_compile MythForgeServer.py`

------
https://chatgpt.com/codex/tasks/task_e_684398a4a648832b84c1e86eaa0ff016