### PR TITLE
Use BOS token in prompt assembly

### DIFF
--- a/MythForgeServer.py
+++ b/MythForgeServer.py
@@ -218,7 +218,7 @@ def build_prompt(chat_id, user_message, message_index, global_prompt_name):
             role = "assistant" if m["role"] == "bot" else m["role"]
             messages.append({"role": role, "content": m["content"]})
 
-    prompt_str = render_prompt(messages)
+    prompt_str = render_prompt(messages, bos_token="<s>")
     return prompt_str
 
 # ========== Standard Chat Endpoints ==========


### PR DESCRIPTION
## Summary
- include `<s>` BOS token when rendering prompts
- `chat` and `chat_stream` still call `build_prompt`

## Testing
- `python -m py_compile MythForgeServer.py lmstudio_prompter.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6843a4329b48832b839a75bbb6ea1989