### PR TITLE
Expose raise_exception in lmstudio_prompter

### DIFF
--- a/lmstudio_prompter.py
+++ b/lmstudio_prompter.py
@@ -1,5 +1,10 @@
 from jinja2 import Template
 
+
+def raise_exception(msg):
+    """Helper used inside the Jinja template to raise runtime errors."""
+    raise RuntimeError(msg)
+
 LMSTUDIO_TEMPLATE = """
 {{- bos_token }}
 {%- if custom_tools is defined %}
@@ -92,6 +97,13 @@ GENERATION_CONFIG = {
 
 
 def render_prompt(messages, bos_token=""):
-    template = Template(LMSTUDIO_TEMPLATE)
-    return template.render(messages=messages, bos_token=bos_token, add_generation_prompt=True)
+    template = Template(
+        LMSTUDIO_TEMPLATE,
+        globals={"raise_exception": raise_exception},
+    )
+    return template.render(
+        messages=messages,
+        bos_token=bos_token,
+        add_generation_prompt=True,
+    )
 


### PR DESCRIPTION
## Summary
- define a `raise_exception` helper for Jinja templating
- pass that helper to the `Template` environment so it can be used inside the template

## Testing
- `python -m py_compile lmstudio_prompter.py MythForgeServer.py`

------
https://chatgpt.com/codex/tasks/task_e_6843a4327d10832b9d7d5d4be3712c45