### PR TITLE
Fix stream token formatting

### DIFF
--- a/MythForgeServer.py
+++ b/MythForgeServer.py
@@ -319,7 +319,8 @@ def chat_stream(req: ChatRequest):
         for output in llm(prompt, max_tokens=250, stream=True, **GENERATION_CONFIG):
             chunk = output["choices"][0]["text"]
             text_accumulator += chunk
-            yield chunk
+            # Each chunk is newline-delimited so the frontend can parse
+            yield chunk + "\n"
 
         # Once done, append full bot response to both histories:
 


### PR DESCRIPTION
## Summary
- ensure newline separated chunks from streaming endpoint

## Testing
- `python -m py_compile MythForgeServer.py lmstudio_prompter.py`

------
https://chatgpt.com/codex/tasks/task_e_6843cbf916c0832bb3dbd2fb19c2ebc2