### PR TITLE
Auto-select new global prompt after creation

### DIFF
--- a/MythForgeUI.html
+++ b/MythForgeUI.html
@@ -425,11 +425,24 @@
             if(name===null) return; const trimmed=name.trim(); if(!trimmed) return alert('Name cannot be empty.');
             const content = prompt(`Enter the text for "${trimmed}":`); if(content===null) return; const contTrim=content.trim(); if(!contTrim) return alert('Prompt content cannot be empty.');
             try{
-                const res = await fetch('/prompts', {method:'POST', headers:{'Content-Type':'application/json'}, body: JSON.stringify({name: trimmed, content: contTrim})});
-                if(!res.ok){ const err=await res.json(); return alert('Error: '+err.detail); }
+                const res = await fetch('/prompts', {
+                    method: 'POST',
+                    headers: { 'Content-Type': 'application/json' },
+                    body: JSON.stringify({ name: trimmed, content: contTrim })
+                });
+                if(!res.ok){
+                    const err = await res.json();
+                    return alert('Error: ' + err.detail);
+                }
+                // Remember this new prompt as the last used one
+                localStorage.setItem('lastGlobalPrompt', trimmed);
                 await refreshGlobalPromptList();
+                gpSelect.value = trimmed;
                 alert(`Prompt "${trimmed}" created.`);
-            }catch(e){ console.error('Failed to create prompt:',e); alert('Failed: '+e.message); }
+            }catch(e){
+                console.error('Failed to create prompt:', e);
+                alert('Failed: ' + e.message);
+            }
         }
 
         async function openPromptEditor(){


### PR DESCRIPTION
## Summary
- update UI to remember newly created global prompts
- set dropdown to newly added prompt automatically

## Testing
- `python -m py_compile MythForgeServer.py lmstudio_prompter.py 'Working Program/MythForgeServer.py' 'Working Program/lmstudio_prompter.py'`
- `python -m py_compile MythForgeServer.py 'Working Program/MythForgeServer.py'`

------
https://chatgpt.com/codex/tasks/task_e_6843d56ab8e4832ba975e9aca6f1781a