### PR TITLE
Only show format line with injection

### DIFF
--- a/airoboros_prompter.py
+++ b/airoboros_prompter.py
@@ -36,9 +36,12 @@ def format_airoboros(
         "BEGINCONTEXT",
         "[SYSTEM] This is law:",
         f"{global_prompt}",
-        f"format: {random_injection}",
-        "ENDCONTEXT",
     ]
+
+    if random_injection:
+        lines.append(f"format: {random_injection}")
+
+    lines.append("ENDCONTEXT")
 
     if summaries:
         lines.append(summaries[-1])


### PR DESCRIPTION
## Summary
- show the `format:` line in Airoboros prompts only when a random injection is present

## Testing
- `python -m py_compile airoboros_prompter.py MythForgeServer.py lmstudio_prompter.py`

------
https://chatgpt.com/codex/tasks/task_e_6843f33fff7c832b801eb87d786217ac