### PR TITLE
Fix UI after deleting chat

### DIFF
--- a/MythForgeUI.html
+++ b/MythForgeUI.html
@@ -482,6 +482,7 @@
                 chatContainer.innerHTML = '';
                 systemPrompt.textContent = '';
                 systemToggle.style.display = 'none';
+                showChatTab();
             }catch(err){ console.error('Failed to delete chat:', err); alert('Error deleting chat: '+err.message); }
         }
 


### PR DESCRIPTION
## Summary
- ensure the UI switches back to the chat tab after deleting a chat

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6843f95dbfdc832b96da3f72f0c89fba