### PR TITLE
Remove jinja template wrapping and log raw prompt

### DIFF
--- a/Working Program/MythForgeServer.py
+++ b/Working Program/MythForgeServer.py
@@ -50,7 +50,7 @@ def load_model() -> None:
     if not os.path.exists(path):
         raise RuntimeError(f"Model file not found: {path}")
 
-    app.state.model = Llama(path)
+    app.state.model = Llama(path, prompt_template="")
 
 
 @app.post("/chat")
@@ -59,6 +59,7 @@ def chat(req: ChatRequest) -> Dict[str, Any]:
         raise HTTPException(status_code=503, detail="Model not loaded")
     input_obj = req.dict()
     prompt = format_prompt(input_obj)
+    print("DEBUG: raw_prompt =", prompt)
     try:
         result = app.state.model(prompt, **GENERATION_CONFIG)
         text = result["choices"][0]["text"]


### PR DESCRIPTION
## Summary
- disable the default chat template when loading the model in `Working Program/MythForgeServer.py`
- log the raw prompt just before calling the model

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_684477fb2fb4832b99b76cf2e048f8f9