### PR TITLE
Add stop and send-only chat controls

### DIFF
--- a/MythForgeServer.py
+++ b/MythForgeServer.py
@@ -414,5 +414,27 @@ def chat_stream(req: ChatRequest):
         media_type="text/plain"
     )
 
+# ─── Endpoint: Log Message Without Generating ------------------------------
+@app.post("/message")
+def log_message(req: ChatRequest):
+    """Record a user message without generating a response."""
+
+    chat_id       = req.chat_id
+    user_message  = req.message
+    global_prompt = req.global_prompt or ""
+
+    os.makedirs(CHATS_DIR, exist_ok=True)
+    full_path    = f"{CHATS_DIR}/{chat_id}_full.json"
+    trimmed_path = f"{CHATS_DIR}/{chat_id}_trimmed.json"
+    if not os.path.exists(full_path):
+        save_json(full_path, [])
+        save_json(trimmed_path, [])
+
+    message_index = len(load_json(full_path))
+    # build_prompt appends the user message to history files
+    build_prompt(chat_id, user_message, message_index, global_prompt)
+
+    return {"detail": "Message recorded"}
+
 # ========== Static UI Mount ==========
 app.mount("/", StaticFiles(directory=".", html=True), name="static")

--- a/MythForgeUI.html
+++ b/MythForgeUI.html
@@ -136,7 +136,7 @@
         .ai-avatar { background-color: var(--primary); color: white; }
         .message-content { flex-grow: 1; max-width: 800px; line-height: 1.6; font-size: var(--message-font-size); }
         pre { background-color: var(--code-bg); color: var(--code-color); padding: 10px; border-radius: 4px; overflow-x: auto; }
-        textarea { width: 100%; padding: 12px 45px 12px 12px; border: 1px solid var(--border-color); border-radius: 6px; resize: none; min-height: 24px; max-height: 200px; overflow-y: auto; font-family: inherit; font-size: var(--message-font-size); line-height: 1.4; background-color: var(--input-bg); color: var(--text-color); }
+        textarea { width: 100%; padding: 12px 110px 12px 12px; border: 1px solid var(--border-color); border-radius: 6px; resize: none; min-height: 24px; max-height: 200px; overflow-y: auto; font-family: inherit; font-size: var(--message-font-size); line-height: 1.4; background-color: var(--input-bg); color: var(--text-color); }
         textarea:focus { outline: none; border-color: var(--primary); box-shadow: 0 0 0 2px var(--shadow-color); }
         .input-area { border-top: 1px solid var(--border-color); padding: 20px; background-color: var(--bg-color); position: relative; }
         .input-container { display: flex; width: 100%; max-width: 800px; margin: 0 auto; position: relative; }
@@ -196,11 +196,17 @@
             <div class="input-area">
                 <div class="input-container">
                     <textarea id="user-input" placeholder="Type a message..." rows="1"></textarea>
+                    <button id="send-only-button" class="send-button" style="right:40px" title="Send without response" disabled>
+                        &#10003;
+                    </button>
                     <button id="send-button" class="send-button" disabled>
                         <svg stroke="currentColor" fill="none" stroke-width="2" viewBox="0 0 24 24" stroke-linecap="round" stroke-linejoin="round" height="20" width="20" xmlns="http://www.w3.org/2000/svg">
                             <line x1="22" y1="2" x2="11" y2="13"></line>
                             <polygon points="22 2 15 22 11 13 2 9 22 2"></polygon>
                         </svg>
+                    </button>
+                    <button id="stop-button" class="send-button" style="display:none" title="Stop generation">
+                        &#9632;
                     </button>
                 </div>
             </div>
@@ -247,6 +253,9 @@
         const chatContainer    = document.getElementById('chat-container');
         const userInput        = document.getElementById('user-input');
         const sendButton       = document.getElementById('send-button');
+        const sendOnlyButton   = document.getElementById('send-only-button');
+        const stopButton       = document.getElementById('stop-button');
+        let abortController    = null;
         const newChatButton    = document.getElementById('new-chat-btn');
         const historyContainer = document.getElementById('history-container');
        const themeSelect      = document.getElementById('theme-select');
@@ -519,14 +528,20 @@
         async function sendMessage(){
             const text = userInput.value.trim();
             if(text==='' || state.isGenerating || !state.currentChatId) return;
-            userInput.value=''; autoResize(); sendButton.disabled=true;
+            userInput.value=''; autoResize();
+            sendButton.disabled=true; sendOnlyButton.disabled=true;
+            sendButton.style.display='none';
+            sendOnlyButton.style.display='none';
+            stopButton.style.display='inline';
             appendMessageToUI('user', text);
             addTyping(); state.isGenerating=true;
+            abortController = new AbortController();
             try{
                 const response = await fetch('/chat/stream', {
                     method:'POST',
                     headers:{'Content-Type':'application/json'},
-                    body: JSON.stringify({chat_id: state.currentChatId, message: text, global_prompt: gpSelect.value})
+                    body: JSON.stringify({chat_id: state.currentChatId, message: text, global_prompt: gpSelect.value}),
+                    signal: abortController.signal
                 });
                 if(!response.ok) throw new Error(`Server returned ${response.status}`);
                 removeTyping();
@@ -558,12 +573,43 @@
                     }
                 }
             }catch(err){
-                console.error('Streaming fetch failed:', err);
-                removeTyping(); appendMessageToUI('assistant','[Error generating response]');
+                if(err.name!=='AbortError'){
+                    console.error('Streaming fetch failed:', err);
+                    removeTyping(); appendMessageToUI('assistant','[Error generating response]');
+                }
             }finally{
-                state.isGenerating=false; sendButton.disabled=userInput.value.trim()===''; userInput.focus();
+                state.isGenerating=false;
+                sendButton.disabled=userInput.value.trim()==='';
+                sendOnlyButton.disabled=sendButton.disabled;
+                stopButton.style.display='none';
+                sendButton.style.display='inline';
+                sendOnlyButton.style.display='inline';
+                userInput.focus();
             }
         }
+
+        async function sendMessageNoGen(){
+            const text = userInput.value.trim();
+            if(text==='' || state.isGenerating || !state.currentChatId) return;
+            userInput.value=''; autoResize();
+            sendButton.disabled=true; sendOnlyButton.disabled=true;
+            appendMessageToUI('user', text);
+            try{
+                await fetch('/message', {
+                    method:'POST',
+                    headers:{'Content-Type':'application/json'},
+                    body: JSON.stringify({chat_id: state.currentChatId, message: text, global_prompt: gpSelect.value})
+                });
+            }catch(err){
+                console.error('Send only failed:', err);
+            }finally{
+                sendButton.disabled=userInput.value.trim()==='' || state.isGenerating;
+                sendOnlyButton.disabled=sendButton.disabled;
+                userInput.focus();
+            }
+        }
+
+        function stopGenerating(){ if(abortController){ abortController.abort(); } }
 
         function setupEvents(){
             themeSelect.addEventListener('change', e=>applyTheme(e.target.value));
@@ -573,8 +619,10 @@
             settingsSaveBtn.addEventListener('click', saveSettingsFromUI);
             settingsModal.addEventListener('click', e=>{ if(e.target===settingsModal) closeSettings(); });
             sendButton.addEventListener('click', sendMessage);
+            sendOnlyButton.addEventListener('click', sendMessageNoGen);
+            stopButton.addEventListener('click', stopGenerating);
             userInput.addEventListener('keydown', e=>{ if(e.key==='Enter' && !e.shiftKey){ e.preventDefault(); sendMessage(); } });
-            userInput.addEventListener('input', ()=>{ sendButton.disabled = userInput.value.trim()==='' || state.isGenerating; autoResize(); });
+            userInput.addEventListener('input', ()=>{ const dis = userInput.value.trim()==='' || state.isGenerating; sendButton.disabled = dis; sendOnlyButton.disabled = dis; autoResize(); });
             userInput.addEventListener('blur', ()=>{ setTimeout(scrollToBottom, 100); });
             newChatButton.addEventListener('click', startNewChat);
             deleteChatBtn.addEventListener('click', deleteChat);


### PR DESCRIPTION
## Summary
- add `/message` endpoint to store a user message without generating
- allow canceling streaming generation on the client
- support sending a message without requesting a reply
- adjust textarea padding for new buttons

## Testing
- `python -m py_compile MythForgeServer.py airoboros_prompter.py lmstudio_prompter.py`

------
https://chatgpt.com/codex/tasks/task_e_68447d342174832b85591fb2d5794662