### PR TITLE
Fix chat listing when server run outside repo root

### DIFF
--- a/MythForgeServer.py
+++ b/MythForgeServer.py
@@ -37,9 +37,12 @@ class PromptItem(BaseModel):
     content: str
 
 # ========== Configuration ==========
-MODELS_DIR            = "models"
-CHATS_DIR             = "chats"
-GLOBAL_PROMPTS_DIR    = "Global_prompts"
+# Resolve data directories relative to this file's location so the server
+# continues to work when executed from a different working directory.
+BASE_DIR              = os.path.dirname(os.path.abspath(__file__))
+MODELS_DIR            = os.path.join(BASE_DIR, "models")
+CHATS_DIR             = os.path.join(BASE_DIR, "chats")
+GLOBAL_PROMPTS_DIR    = os.path.join(BASE_DIR, "Global_prompts")
 # Match LM Studio defaults for a 4 GB VRAM setup
 DEFAULT_CTX_SIZE      = 4096
 DEFAULT_N_BATCH       = 512


### PR DESCRIPTION
## Summary
- ensure chat, model, and prompt directories are resolved relative to the server file

## Testing
- `python -m py_compile MythForgeServer.py`

------
https://chatgpt.com/codex/tasks/task_e_684496baded0832b9d8e3ea87047d6fc