### PR TITLE
Add debug print of prompts

### DIFF
--- a/MythForgeServer.py
+++ b/MythForgeServer.py
@@ -208,6 +208,7 @@ def summarize_chunk(chunk):
         f"BEGININSTRUCTION\nSummarize the above conversation in 2-3 sentences.\nENDINSTRUCTION"
     )
     # Use ``call_llm`` to ensure only supported kwargs are passed to the model
+    print("DEBUG raw_prompt:", prompt)
     output = call_llm(prompt, max_tokens=150)
     return {"type": "summary", "content": output["choices"][0]["text"].strip()}
 
@@ -406,6 +407,7 @@ def chat(req: ChatRequest):
     )
 
     # Generate the assistant response using LM Studio generation settings
+    print("DEBUG raw_prompt:", prompt)
     output = call_llm(prompt, max_tokens=250, **GENERATION_CONFIG)
     response_text = output["choices"][0]["text"].strip()
     response_text = strip_leading_tag(response_text, assistant_name)
@@ -465,6 +467,7 @@ def chat_stream(req: ChatRequest):
         prefix_trimmed = False
         prefix = f"{assistant_name}:"
 
+        print("DEBUG raw_prompt:", prompt)
         for output in call_llm(
             prompt,
             max_tokens=250,


### PR DESCRIPTION
## Summary
- log prompts before sending them to the model

## Testing
- `python -m py_compile MythForgeServer.py`

------
https://chatgpt.com/codex/tasks/task_e_68449a5d3bfc832bb84f1064b4348105