### PR TITLE
Fix rename to same name

### DIFF
--- a/MythForgeServer.py
+++ b/MythForgeServer.py
@@ -225,6 +225,8 @@ def rename_prompt(name: str, data: Dict[str, str]):
     prompts = load_global_prompts()
     if not any(p["name"] == name for p in prompts):
         raise HTTPException(status_code=404, detail="Prompt not found")
+    if new_name == name:
+        return {"detail": f"Renamed prompt '{name}' to '{new_name}'"}
     if any(p["name"] == new_name for p in prompts):
         raise HTTPException(status_code=400, detail="Prompt name already exists")
 
@@ -418,6 +420,9 @@ def rename_chat(chat_id: str, data: Dict[str, str]):
     new_id = data.get("new_id", "").strip()
     if not new_id:
         raise HTTPException(status_code=400, detail="New chat id required")
+
+    if new_id == chat_id:
+        return {"detail": f"Renamed chat '{chat_id}' to '{new_id}'"}
 
     old_full = f"{CHATS_DIR}/{chat_id}_full.json"
     old_trim = f"{CHATS_DIR}/{chat_id}_trimmed.json"

--- a/MythForgeUI.html
+++ b/MythForgeUI.html
@@ -573,6 +573,7 @@
         async function renameChat(oldId){
             const name = prompt('Enter new chat name:', oldId); if(name===null) return;
             const trimmed = name.trim(); if(!trimmed) return alert('Name cannot be empty.');
+            if(trimmed === oldId) return;
             if(state.chats.includes(trimmed)) return alert('That name\u2019s already taken.');
             try{
                 const res = await fetch(`/chat/${encodeURIComponent(oldId)}`, {
@@ -617,6 +618,7 @@
             const newName = prompt('Enter new prompt name:', oldName);
             if(newName===null) return;
             const trimmed = newName.trim(); if(!trimmed) return alert('Name cannot be empty.');
+            if(trimmed === oldName) return;
             if(state.prompts.includes(trimmed)) return alert('That name\u2019s already taken.');
             try{
                 const res = await fetch(`/prompts/${encodeURIComponent(oldName)}/rename`, {


### PR DESCRIPTION
## Summary
- allow renaming chats and prompts to their current names
- skip duplicate name checks in this case

## Testing
- `python -m py_compile MythForgeServer.py`

------
https://chatgpt.com/codex/tasks/task_e_68449edd53fc832bb5b7f0517285e746