### PR TITLE
Fix no-op rename editing bug

### DIFF
--- a/MythForgeUI.html
+++ b/MythForgeUI.html
@@ -617,8 +617,9 @@
         async function renamePrompt(oldName){
             const newName = prompt('Enter new prompt name:', oldName);
             if(newName===null) return;
-            const trimmed = newName.trim(); if(!trimmed) return alert('Name cannot be empty.');
-            if(trimmed === oldName) return;
+            const trimmed = newName.trim();
+            if(!trimmed) return alert('Name cannot be empty.');
+            if(trimmed.toLowerCase() === oldName.trim().toLowerCase()) return;
             if(state.prompts.includes(trimmed)) return alert('That name\u2019s already taken.');
             try{
                 const res = await fetch(`/prompts/${encodeURIComponent(oldName)}/rename`, {


### PR DESCRIPTION
## Summary
- prevent editing prompt content when renamed to same name

## Testing
- `python3 -m py_compile MythForgeServer.py airoboros_prompter.py`


------
https://chatgpt.com/codex/tasks/task_e_6844a0626b8c832ba372cc4e224786de