### PR TITLE
Allow renaming prompt to same name

### DIFF
--- a/MythForgeUI.html
+++ b/MythForgeUI.html
@@ -619,8 +619,8 @@
             if(newName===null) return;
             const trimmed = newName.trim();
             if(!trimmed) return alert('Name cannot be empty.');
-            if(trimmed.toLowerCase() === oldName.trim().toLowerCase()) return;
-            if(state.prompts.includes(trimmed)) return alert('That name\u2019s already taken.');
+            if(trimmed.toLowerCase() !== oldName.trim().toLowerCase() && state.prompts.includes(trimmed))
+                return alert('That name\u2019s already taken.');
             try{
                 const res = await fetch(`/prompts/${encodeURIComponent(oldName)}/rename`, {
                     method:'PUT',


### PR DESCRIPTION
## Summary
- allow rename endpoint to accept same-name updates
- don't block renaming in UI when name doesn't change

## Testing
- `python3 -m py_compile MythForgeServer.py`

------
https://chatgpt.com/codex/tasks/task_e_6844a3150b3c832bbdc150acd474de77