### PR TITLE
Fix sidebar and tab width

### DIFF
--- a/MythForgeUI.html
+++ b/MythForgeUI.html
@@ -102,6 +102,8 @@
         .app-container { display: flex; width: 100%; height: 100%; }
         .sidebar {
             width: 260px;
+            flex: 0 0 260px;
+            box-sizing: border-box;
             background-color: var(--sidebar-bg);
             color: var(--sidebar-text);
             padding: 16px;
@@ -113,6 +115,8 @@
         .sidebar button.new-chat { padding: 12px; text-align: left; margin-bottom: 20px; display: flex; align-items: center; }
         .history-container { flex-grow: 1; overflow-y: auto; }
         .chat-history-item {
+            width: 100%;
+            box-sizing: border-box;
             padding: 10px; margin-bottom: 5px; border-radius: 4px; cursor: pointer; font-size: 14px; position: relative; display:flex; align-items:center;
         }
         .chat-name { flex-grow:1; overflow:hidden; text-overflow:ellipsis; white-space:nowrap; }
@@ -155,6 +159,8 @@
 
         .tab-bar {
             width: 40px;
+            flex: 0 0 40px;
+            box-sizing: border-box;
             background-color: var(--sidebar-bg);
             color: var(--sidebar-text);
             display: flex;


### PR DESCRIPTION
## Summary
- prevent `sidebar` and `tab-bar` from shrinking or expanding
- ensure chat history items always fit within sidebar

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_6844a7d975b8832bac755f23dfdf3638