### PR TITLE
Fix newline handling in streaming output

### DIFF
--- a/MythForgeServer.py
+++ b/MythForgeServer.py
@@ -514,6 +514,7 @@ def chat_stream(req: ChatRequest):
     def generate_and_stream():
         # First, send a single line of JSON with the prompt:
         meta = json.dumps({"prompt": prompt}, ensure_ascii=False)
+        # Send one line of JSON metadata followed by raw token text
         yield meta + "\n"
 
         text_accumulator = ""
@@ -531,7 +532,7 @@ def chat_stream(req: ChatRequest):
             chunk = output["choices"][0]["text"]
             if prefix_trimmed:
                 text_accumulator += chunk
-                yield chunk + "\n"
+                yield chunk
                 continue
 
             pending += chunk
@@ -540,12 +541,12 @@ def chat_stream(req: ChatRequest):
                 if len(check) > len(prefix):
                     trimmed = strip_leading_tag(check, assistant_name)
                     text_accumulator += trimmed
-                    yield trimmed + "\n"
+                    yield trimmed
                     prefix_trimmed = True
                     pending = ""
             else:
                 text_accumulator += pending
-                yield pending + "\n"
+                yield pending
                 prefix_trimmed = True
                 pending = ""
 

--- a/MythForgeUI.html
+++ b/MythForgeUI.html
@@ -754,28 +754,38 @@
                 const aiElement = chatContainer.lastChild.querySelector('.message-content');
                 const reader = response.body.getReader();
                 const decoder = new TextDecoder('utf-8');
-                let buffer=''; let done=false; let firstLine=true; let accumulated='';
-                while(!done){
-                    const {value, done:doneReading} = await reader.read();
-                    done = doneReading;
+                let buffer = '';
+                let gotMeta = false;
+                let accumulated = '';
+                while(true){
+                    const {value, done} = await reader.read();
                     if(value){
-                        buffer += decoder.decode(value, {stream:true});
-                        while(buffer.includes('\n')){
-                            const idx = buffer.indexOf('\n');
-                            const chunk = buffer.slice(0, idx); buffer = buffer.slice(idx+1);
-                            if(firstLine){
-                                firstLine=false;
-                                try{
-                                    const meta=JSON.parse(chunk);
-                                    systemPrompt.textContent = meta.prompt || '';
-                                    systemToggle.style.display = meta.prompt ? 'block' : 'none';
-                                }catch{}
-                            }else{
-                                accumulated += chunk; aiElement.innerHTML = accumulated.replace(/\n/g,'<br>');
-                                chatContainer.scrollTop = chatContainer.scrollHeight;
-                            }
+                        buffer += decoder.decode(value, {stream: !done});
+                    }
+                    if(!gotMeta){
+                        const idx = buffer.indexOf('\n');
+                        if(idx !== -1){
+                            const metaStr = buffer.slice(0, idx);
+                            buffer = buffer.slice(idx + 1);
+                            try{
+                                const meta = JSON.parse(metaStr);
+                                systemPrompt.textContent = meta.prompt || '';
+                                systemToggle.style.display = meta.prompt ? 'block' : 'none';
+                            }catch{}
+                            gotMeta = true;
+                        }else if(done){
+                            break;
+                        }else{
+                            continue;
                         }
                     }
+                    if(gotMeta && buffer){
+                        accumulated += buffer;
+                        aiElement.innerHTML = accumulated.replace(/\n/g,'<br>');
+                        chatContainer.scrollTop = chatContainer.scrollHeight;
+                        buffer = '';
+                    }
+                    if(done) break;
                 }
             }catch(err){
                 if(err.name!=='AbortError'){


### PR DESCRIPTION
## Summary
- stream raw tokens without extra newline delimiters
- update frontend to parse metadata then append all text

## Testing
- `python -m py_compile MythForgeServer.py airoboros_prompter.py`

------
https://chatgpt.com/codex/tasks/task_e_6844ae284114832b8fb03280fca3b7e7