### PR TITLE
Fix newline on start of streaming responses

### DIFF
--- a/MythForgeUI.html
+++ b/MythForgeUI.html
@@ -780,6 +780,9 @@
                         }
                     }
                     if(gotMeta && buffer){
+                        if(accumulated==='' && buffer.startsWith('\n')){
+                            buffer = buffer.replace(/^\n+/, '');
+                        }
                         accumulated += buffer;
                         aiElement.innerHTML = accumulated.replace(/\n/g,'<br>');
                         chatContainer.scrollTop = chatContainer.scrollHeight;


### PR DESCRIPTION
## Summary
- trim leading newline from the first streamed chunk so text doesn't start on a blank line

## Testing
- `python -m py_compile MythForgeServer.py airoboros_prompter.py`


------
https://chatgpt.com/codex/tasks/task_e_6844afde5b08832b87f8529b4cb28309