### PR TITLE
Fix empty prompt handling

### DIFF
--- a/MythForgeServer.py
+++ b/MythForgeServer.py
@@ -294,16 +294,15 @@ def build_prompt(chat_id, user_message, message_index, global_prompt_name):
     trimmed_path = f"{CHATS_DIR}/{chat_id}_trimmed.json"
     full_path = f"{CHATS_DIR}/{chat_id}_full.json"
 
-    # Append user message to full history
+    # Append user message to history if it is not empty.  When generating with
+    # an empty prompt, we do not want to record a blank user message.
     full_log = load_json(full_path)
-    full_log.append({"role": "user", "content": user_message})
-    save_json(full_path, full_log)
-
-    # Load existing trimmed context and append the new user message.
-    # Summarization is handled separately after the assistant responds so
-    # the full user+assistant exchange can be summarized together.
     context = load_json(trimmed_path)
-    context.append({"type": "raw", "role": "user", "content": user_message})
+    if user_message.strip():
+        full_log.append({"role": "user", "content": user_message})
+        context.append({"type": "raw", "role": "user", "content": user_message})
+    # Ensure history files exist even if no message was appended
+    save_json(full_path, full_log)
     save_json(trimmed_path, context)
 
     # Determine system prompt

--- a/MythForgeUI.html
+++ b/MythForgeUI.html
@@ -739,7 +739,7 @@
             sendButton.style.display='none';
             sendOnlyButton.style.display='none';
             stopButton.style.display='inline';
-            appendMessageToUI('user', text);
+            if(text!=='') appendMessageToUI('user', text);
             addTyping(); state.isGenerating=true;
             abortController = new AbortController();
             try{


### PR DESCRIPTION
## Summary
- avoid logging empty messages when no prompt is provided
- skip adding empty user messages in the UI

## Testing
- `python -m py_compile MythForgeServer.py airoboros_prompter.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6844b2ec00c0832bac6c0c9e46b4f487