### PR TITLE
Add summarization settings

### DIFF
--- a/MythForgeServer.py
+++ b/MythForgeServer.py
@@ -46,8 +46,6 @@ SETTINGS_PATH      = "settings.json"
 DEFAULT_CTX_SIZE   = 4096
 DEFAULT_N_BATCH    = 512
 DEFAULT_N_THREADS  = os.cpu_count() or 1
-SUMMARIZE_THRESHOLD = 20
-SUMMARIZE_BATCH     = 12
 
 
 def load_settings(path: str = SETTINGS_PATH) -> Dict[str, object]:
@@ -76,6 +74,8 @@ GENERATION_CONFIG = {
     "stop": SETTINGS.get("stop", ["<|start_header_id|>", "<|eot_id|>"]),
 }
 DEFAULT_MAX_TOKENS = SETTINGS.get("max_tokens", 250)
+SUMMARIZE_THRESHOLD = SETTINGS.get("summarize_threshold", 20)
+SUMMARIZE_BATCH     = SETTINGS.get("summarize_batch", 12)
 
 # ========== Model Loading ==========
 def discover_model_path():

--- a/README.md
+++ b/README.md
@@ -1,0 +1,17 @@
+# MythForge
+
+MythForge is a lightweight chat server that runs on top of `llama_cpp`.
+It exposes a simple REST API and includes a small web UI.
+
+## Settings
+
+Configuration is loaded from `settings.json` in the project root.  Most
+options mirror the parameters exposed by `llama_cpp`.  Two additional
+values control when old messages are summarized:
+
+- `summarize_threshold` – number of raw messages stored before the
+  server begins summarizing.
+- `summarize_batch` – how many messages to summarize at a time.
+
+Adjust these numbers to tweak context trimming behaviour.  The default
+values are suitable for most small models.

--- a/settings.json
+++ b/settings.json
@@ -18,5 +18,7 @@
   "repeat_penalty": 1.1,
   "stop": ["<|start_header_id|>", "<|eot_id|>"],
   "stream": false,
-  "echo": false
+  "echo": false,
+  "summarize_threshold": 20,
+  "summarize_batch": 12
 }


### PR DESCRIPTION
## Summary
- allow customizing summarization behaviour via settings.json
- hook MythForgeServer into new settings
- document configuration in README

## Testing
- `python3 -m py_compile MythForgeServer.py`


------
https://chatgpt.com/codex/tasks/task_e_6844b475d820832bbc2c45bbf2395068