### PR TITLE
Handle JSON decode failures in server

### DIFF
--- a/MythForgeServer.py
+++ b/MythForgeServer.py
@@ -138,7 +138,10 @@ def call_llm(prompt: str, **kwargs):
 def load_json(path):
     if os.path.exists(path):
         with open(path, 'r', encoding='utf-8') as f:
-            return json.load(f)
+            try:
+                return json.load(f)
+            except json.JSONDecodeError as e:
+                print(f"Failed to parse JSON from '{path}': {e}")
     return []
 
 def save_json(path, data):


### PR DESCRIPTION
## Summary
- wrap `json.load` in a try/except in `load_json`

## Testing
- `python -m py_compile MythForgeServer.py`


------
https://chatgpt.com/codex/tasks/task_e_6844b4b0ac70832b924fe99ba3fa8287