### PR TITLE
Add server-side generation settings

### DIFF
--- a/MythForgeServer.py
+++ b/MythForgeServer.py
@@ -27,6 +27,12 @@ class ChatRequest(BaseModel):
     chat_id: str
     message: str
     global_prompt: str = ""
+    max_tokens: int | None = None
+    temperature: float | None = None
+    top_k: int | None = None
+    top_p: float | None = None
+    min_p: float | None = None
+    repeat_penalty: float | None = None
 
 class ChatResponse(BaseModel):
     response: str
@@ -461,9 +467,21 @@ def chat(req: ChatRequest):
         chat_id, user_message, global_prompt
     )
 
-    # Generate the assistant response using LM Studio generation settings
+    config = GENERATION_CONFIG.copy()
+    if req.temperature is not None:
+        config["temperature"] = req.temperature
+    if req.top_k is not None:
+        config["top_k"] = req.top_k
+    if req.top_p is not None:
+        config["top_p"] = req.top_p
+    if req.min_p is not None:
+        config["min_p"] = req.min_p
+    if req.repeat_penalty is not None:
+        config["repeat_penalty"] = req.repeat_penalty
+    max_tokens = req.max_tokens if req.max_tokens is not None else DEFAULT_MAX_TOKENS
+
     print("DEBUG raw_prompt:", prompt)
-    output = call_llm(prompt, max_tokens=DEFAULT_MAX_TOKENS, **GENERATION_CONFIG)
+    output = call_llm(prompt, max_tokens=max_tokens, **config)
     response_text = output["choices"][0]["text"].strip()
     response_text = strip_leading_tag(response_text, assistant_name)
 
@@ -523,11 +541,24 @@ def chat_stream(req: ChatRequest):
         prefix = f"{assistant_name}:"
 
         print("DEBUG raw_prompt:", prompt)
+        config = GENERATION_CONFIG.copy()
+        if req.temperature is not None:
+            config["temperature"] = req.temperature
+        if req.top_k is not None:
+            config["top_k"] = req.top_k
+        if req.top_p is not None:
+            config["top_p"] = req.top_p
+        if req.min_p is not None:
+            config["min_p"] = req.min_p
+        if req.repeat_penalty is not None:
+            config["repeat_penalty"] = req.repeat_penalty
+        max_tokens = req.max_tokens if req.max_tokens is not None else DEFAULT_MAX_TOKENS
+
         for output in call_llm(
             prompt,
-            max_tokens=DEFAULT_MAX_TOKENS,
+            max_tokens=max_tokens,
             stream=True,
-            **GENERATION_CONFIG,
+            **config,
         ):
             chunk = output["choices"][0]["text"]
             if prefix_trimmed:
@@ -590,6 +621,23 @@ def log_message(req: ChatRequest):
     build_prompt(chat_id, user_message, global_prompt)
 
     return {"detail": "Message recorded"}
+
+# ========== Settings Endpoints ==========
+@app.get("/settings")
+def get_settings():
+    return SETTINGS
+
+@app.put("/settings")
+def update_settings(data: Dict[str, object]):
+    """Update settings and persist them to ``settings.json``."""
+    SETTINGS.update(data)
+    save_json(SETTINGS_PATH, SETTINGS)
+    for key in ("temperature", "top_k", "top_p", "min_p", "repeat_penalty", "stop"):
+        if key in SETTINGS:
+            GENERATION_CONFIG[key] = SETTINGS[key]
+    global DEFAULT_MAX_TOKENS
+    DEFAULT_MAX_TOKENS = SETTINGS.get("max_tokens", DEFAULT_MAX_TOKENS)
+    return {"detail": "Updated", "settings": SETTINGS}
 
 # ========== Static UI Mount ==========
 app.mount("/", StaticFiles(directory=".", html=True), name="static")

--- a/MythForgeUI.html
+++ b/MythForgeUI.html
@@ -176,6 +176,8 @@
         #prompt-section { overflow-y: auto; }
         .sidebar-section { display: flex; flex-direction: column; gap: 8px; margin-bottom: 20px; }
         .sidebar-section select { background-color: var(--sidebar-btn-bg); color: var(--sidebar-text); border: 1px solid rgba(255,255,255,0.2); border-radius: 4px; padding: 8px; cursor: pointer; font-size: 14px; }
+        .sidebar-section label { display:flex; flex-direction:column; font-size:14px; }
+        .sidebar-section input { background-color: var(--sidebar-btn-bg); color: var(--sidebar-text); border: 1px solid rgba(255,255,255,0.2); border-radius:4px; padding:6px 8px; margin-top:4px; font-size:14px; }
     </style>
 </head>
 <body>
@@ -196,7 +198,16 @@
                 <div class="history-container" id="prompt-list"></div>
             </div>
             <div id="more-section" style="display:none;">
-                <button id="open-settings-btn" class="new-chat">Settings</button>
+                <button id="open-settings-btn" class="new-chat">Local Settings</button>
+                <div class="sidebar-section" id="generation-settings">
+                    <label>Max Tokens <input id="max-tokens-input" type="number" min="1"></label>
+                    <label>Temperature <input id="temperature-input" type="number" step="0.01"></label>
+                    <label>Top K <input id="top-k-input" type="number" min="0"></label>
+                    <label>Top P <input id="top-p-input" type="number" step="0.01" min="0" max="1"></label>
+                    <label>Min P <input id="min-p-input" type="number" step="0.01" min="0" max="1"></label>
+                    <label>Repeat Penalty <input id="repeat-penalty-input" type="number" step="0.01" min="0"></label>
+                    <button id="server-settings-save-btn">Save</button>
+                </div>
                 <button id="system-toggle" class="new-chat" style="display:none;margin-top:10px;">⚙️ Last Prompt</button>
             </div>
         </div>
@@ -248,7 +259,7 @@
                     <option value="xx-large">2x Large</option>
                     <option value="xxx-large">3x Large</option>
                     <option value="xxxx-large">4x Large</option>
-                    <option value="xxxxx-large">5x Large</option>
+                <option value="xxxxx-large">5x Large</option>
                 </select>
             </div>
             <div class="modal-actions">
@@ -259,7 +270,27 @@
 
     <script>
         const CONFIG = { apiUrl: window.location.origin };
-        const state = { chats: [], currentChatId: '', prompts: [], currentPrompt:'', settings:{ userName:'You', botName:'Bot', theme:'light', textSize:'medium' }, isGenerating: false };
+        const state = {
+            chats: [],
+            currentChatId: '',
+            prompts: [],
+            currentPrompt: '',
+            settings: {
+                userName: 'You',
+                botName: 'Bot',
+                theme: 'light',
+                textSize: 'medium'
+            },
+            serverSettings: {
+                max_tokens: 250,
+                temperature: 0.8,
+                top_k: 40,
+                top_p: 0.95,
+                min_p: 0.05,
+                repeat_penalty: 1.1
+            },
+            isGenerating: false
+        };
 
         const chatContainer    = document.getElementById('chat-container');
         const userInput        = document.getElementById('user-input');
@@ -281,6 +312,13 @@
         const settingsSaveBtn  = document.getElementById('settings-save-btn');
         const userNameInput    = document.getElementById('user-name-input');
         const botNameInput     = document.getElementById('bot-name-input');
+        const maxTokensInput   = document.getElementById('max-tokens-input');
+        const temperatureInput = document.getElementById('temperature-input');
+        const topKInput        = document.getElementById('top-k-input');
+        const topPInput        = document.getElementById('top-p-input');
+        const minPInput        = document.getElementById('min-p-input');
+        const repeatPenaltyInput = document.getElementById('repeat-penalty-input');
+        const serverSettingsSaveBtn = document.getElementById('server-settings-save-btn');
         const hideTab          = document.getElementById('hide-tab');
         const chatTab          = document.getElementById('chat-tab');
         const promptTab        = document.getElementById('prompt-tab');
@@ -313,12 +351,24 @@
         function loadSettings(){
             const saved = localStorage.getItem('clientSettings');
             if(saved){
-                try{ Object.assign(state.settings, JSON.parse(saved)); }catch{}
+                try{
+                    const obj = JSON.parse(saved);
+                    if(obj.userName) state.settings.userName = obj.userName;
+                    if(obj.botName)  state.settings.botName  = obj.botName;
+                    if(obj.theme)    state.settings.theme    = obj.theme;
+                    if(obj.textSize) state.settings.textSize = obj.textSize;
+                }catch{}
             }
         }
 
         function saveSettings(){
-            localStorage.setItem('clientSettings', JSON.stringify(state.settings));
+            const obj = {
+                userName: state.settings.userName,
+                botName: state.settings.botName,
+                theme: state.settings.theme,
+                textSize: state.settings.textSize
+            };
+            localStorage.setItem('clientSettings', JSON.stringify(obj));
         }
 
         function loadTheme(){
@@ -331,7 +381,43 @@
             textSizeSelect.value = state.settings.textSize;
         }
 
-        function openSettings(){
+        async function loadServerSettings(){
+            try{
+                const res = await fetch('/settings');
+                if(!res.ok) return;
+                const data = await res.json();
+                state.serverSettings = data;
+                maxTokensInput.value     = data.max_tokens ?? '';
+                temperatureInput.value   = data.temperature ?? '';
+                topKInput.value          = data.top_k ?? '';
+                topPInput.value          = data.top_p ?? '';
+                minPInput.value          = data.min_p ?? '';
+                repeatPenaltyInput.value = data.repeat_penalty ?? '';
+            }catch(e){ console.error('Failed to load server settings:', e); }
+        }
+
+        async function saveServerSettings(){
+            const payload = {
+                max_tokens: parseInt(maxTokensInput.value) || 1,
+                temperature: parseFloat(temperatureInput.value) || 0,
+                top_k: parseInt(topKInput.value) || 0,
+                top_p: parseFloat(topPInput.value) || 0,
+                min_p: parseFloat(minPInput.value) || 0,
+                repeat_penalty: parseFloat(repeatPenaltyInput.value) || 0
+            };
+            try{
+                const res = await fetch('/settings', {method:'PUT', headers:{'Content-Type':'application/json'}, body: JSON.stringify(payload)});
+                if(!res.ok){
+                    const err = await res.json();
+                    alert('Error: ' + (err.detail || res.status));
+                    return;
+                }
+                state.serverSettings = {...state.serverSettings, ...payload};
+                alert('Settings saved');
+            }catch(e){ console.error('Failed to save server settings:', e); }
+        }
+
+       function openSettings(){
             userNameInput.value = state.settings.userName;
             botNameInput.value  = state.settings.botName;
             themeSelect.value   = state.settings.theme;
@@ -350,7 +436,7 @@
             });
         }
 
-        function saveSettingsFromUI(){
+       function saveSettingsFromUI(){
             state.settings.userName = userNameInput.value.trim() || 'You';
             state.settings.botName  = botNameInput.value.trim()  || 'Bot';
             applyTheme(themeSelect.value);
@@ -746,7 +832,11 @@
                 const response = await fetch('/chat/stream', {
                     method:'POST',
                     headers:{'Content-Type':'application/json'},
-                    body: JSON.stringify({chat_id: state.currentChatId, message: text, global_prompt: state.currentPrompt}),
+                    body: JSON.stringify({
+                        chat_id: state.currentChatId,
+                        message: text,
+                        global_prompt: state.currentPrompt
+                    }),
                     signal: abortController.signal
                 });
                 if(!response.ok) throw new Error(`Server returned ${response.status}`);
@@ -836,6 +926,7 @@
             // prompt selection handled in render
             openSettingsBtn.addEventListener('click', openSettings);
             settingsSaveBtn.addEventListener('click', saveSettingsFromUI);
+            serverSettingsSaveBtn.addEventListener('click', saveServerSettings);
             settingsModal.addEventListener('click', e=>{ if(e.target===settingsModal) closeSettings(); });
             sendButton.addEventListener('click', () => {
                 if(userInput.value.trim()===''){
@@ -867,6 +958,7 @@
             await fetchChatList();
             if(state.currentChatId) await loadChat(state.currentChatId);
             await refreshGlobalPromptList();
+            await loadServerSettings();
             autoResize();
         })();
     </script>


### PR DESCRIPTION
## Summary
- move generation parameter controls from settings modal to sidebar
- rename settings button to *Local Settings*
- store generation parameters on the server and expose `/settings` endpoints
- load and save server settings via new sidebar controls

## Testing
- `python -m py_compile MythForgeServer.py`


------
https://chatgpt.com/codex/tasks/task_e_6844b56cf344832bbbc317d63e4615f2