### PR TITLE
Remove system law line from airoboros prompt

### DIFF
--- a/airoboros_prompter.py
+++ b/airoboros_prompter.py
@@ -33,7 +33,6 @@ def format_airoboros(
     lines = [
         "BEGININPUT",
         "BEGINCONTEXT",
-        "[SYSTEM] This is law:",
         f"{global_prompt}",
         "ENDCONTEXT",
     ]


### PR DESCRIPTION
## Summary
- the Airoboros prompt no longer includes the `[SYSTEM] This is law:` line

## Testing
- `python -m py_compile airoboros_prompter.py MythForgeServer.py`

------
https://chatgpt.com/codex/tasks/task_e_6844c0344e38832b87b50c6cbbe4e9e3