### PR TITLE
Fix duplicate user prompt

### DIFF
--- a/MythForgeServer.py
+++ b/MythForgeServer.py
@@ -340,7 +340,7 @@ def build_prompt(chat_id, user_message, global_prompt_name):
         system_prompt,
         summaries,
         history,
-        user_message,
+        "",
         assistant_name,
     )
     return prompt_str, assistant_name


### PR DESCRIPTION
## Summary
- remove last user message when building the llama3 prompt

## Testing
- `python -m py_compile MythForgeServer.py airoboros_prompter.py`


------
https://chatgpt.com/codex/tasks/task_e_6844de2255d8832b9f3b78ca19701b05