### PR TITLE
Auto-create named chats and prompts

### DIFF
--- a/MythForgeUI.html
+++ b/MythForgeUI.html
@@ -613,25 +613,27 @@
         }
 
         async function addNewPrompt(){
-            const name = prompt('Enter a unique prompt name (no spaces):');
-            if(name===null) return; const trimmed=name.trim(); if(!trimmed) return alert('Name cannot be empty.');
-            const content = prompt(`Enter the text for "${trimmed}":`); if(content===null) return; const contTrim=content.trim(); if(!contTrim) return alert('Prompt content cannot be empty.');
+            const existing = state.prompts.map(p => p.toLowerCase());
+            let idx = 1;
+            let name = `New Prompt ${idx}`;
+            while(existing.includes(name.toLowerCase())){
+                idx++;
+                name = `New Prompt ${idx}`;
+            }
             try{
                 const res = await fetch('/prompts', {
                     method: 'POST',
                     headers: { 'Content-Type': 'application/json' },
-                    body: JSON.stringify({ name: trimmed, content: contTrim })
+                    body: JSON.stringify({ name: name, content: '' })
                 });
                 if(!res.ok){
                     const err = await res.json();
                     return alert('Error: ' + err.detail);
                 }
-                // Remember this new prompt as the last used one
-                localStorage.setItem('lastGlobalPrompt', trimmed);
+                localStorage.setItem('lastGlobalPrompt', name);
                 await refreshGlobalPromptList();
-                state.currentPrompt = trimmed;
+                state.currentPrompt = name;
                 renderPromptList();
-                alert(`Prompt "${trimmed}" created.`);
             }catch(e){
                 console.error('Failed to create prompt:', e);
                 alert('Failed: ' + e.message);
@@ -652,15 +654,20 @@
         }
 
         function startNewChat(){
-            const name = prompt('Enter new chat name:'); if(name===null) return; const trimmed = name.trim(); if(!trimmed) return alert('Name cannot be empty.');
-            if(state.chats.includes(trimmed)) return alert('That name\u2019s already taken.');
-              state.chats.unshift(trimmed);
-              state.currentChatId = trimmed;
-              localStorage.setItem('lastChatId', trimmed);
-              renderHistory();
-              chatContainer.innerHTML = '';
-              systemPrompt.textContent = '';
-              systemToggle.style.display = 'none';
+            const existing = state.chats.map(c => c.toLowerCase());
+            let idx = 1;
+            let name = `New Chat ${idx}`;
+            while(existing.includes(name.toLowerCase())){
+                idx++;
+                name = `New Chat ${idx}`;
+            }
+            state.chats.unshift(name);
+            state.currentChatId = name;
+            localStorage.setItem('lastChatId', name);
+            renderHistory();
+            chatContainer.innerHTML = '';
+            systemPrompt.textContent = '';
+            systemToggle.style.display = 'none';
         }
 
         async function deleteChat(){


### PR DESCRIPTION
## Summary
- make `New Chat` button instantly create a chat named `New Chat X`
- make `New Prompt` button instantly create a prompt named `New Prompt X`

## Testing
- `python -m py_compile MythForgeServer.py airoboros_prompter.py`


------
https://chatgpt.com/codex/tasks/task_e_6844e51bf604832ba058c7fceae135a1