### PR TITLE
Fix goal tracker prompts and logging

### DIFF
--- a/airoboros_prompter.py
+++ b/airoboros_prompter.py
@@ -41,6 +41,11 @@ def format_llama3(
 
     messages: List[Dict[str, str]] = []
 
+    # Remove any stray header tokens from user provided text to avoid
+    # duplicating them in the final prompt.
+    global_prompt = _strip_junk(global_prompt)
+    instruction = _strip_junk(instruction)
+
     system_parts: List[str] = []
     if global_prompt:
         system_parts.append(global_prompt.strip())
@@ -72,7 +77,10 @@ def format_llama3(
     lines.append("<|start_header_id|>assistant<|end_header_id|>")
     lines.append("")
 
-    return "\n".join(lines)
+    prompt = "\n".join(lines)
+    # Guard against accidental duplication of the begin token
+    prompt = re.sub(r"^(<\|begin_of_text\|>)+", "<|begin_of_text|>", prompt)
+    return prompt
 
 
 def main() -> None:


### PR DESCRIPTION
## Summary
- sanitize global prompts and instructions to avoid duplicated LLaMA3 tokens
- collapse repeated `<|begin_of_text|>` tokens in prompts
- add progress output during goal creation

## Testing
- `pytest -q`
- `python -m py_compile MythForgeServer.py goal_tracker.py airoboros_prompter.py`

------
https://chatgpt.com/codex/tasks/task_e_6844f7141d44832b87bdb1c44f38abe7