### PR TITLE
Adjust stop tokens to avoid prefix-match warnings

### DIFF
--- a/MythForgeServer.py
+++ b/MythForgeServer.py
@@ -89,7 +89,11 @@ GENERATION_CONFIG = {
     # ``n_batch`` is set when ``Llama`` is instantiated. Passing it to
     # ``Llama.__call__`` can break older ``llama_cpp`` versions, so it is
     # intentionally omitted here.
-    "stop": SETTINGS.get("stop", ["<|start_header_id|>", "<|eot_id|>"]),
+    # ``<|start_header_id|>`` is omitted from the default stop list to avoid
+    # the "prefix-match" warnings emitted by ``llama_cpp`` when the model
+    # begins generating the next header token.  ``<|eot_id|>`` alone is
+    # sufficient to mark the end of an assistant message.
+    "stop": SETTINGS.get("stop", ["<|eot_id|>"]),
 }
 DEFAULT_MAX_TOKENS = SETTINGS.get("max_tokens", 250)
 SUMMARIZE_THRESHOLD = SETTINGS.get("summarize_threshold", 20)

--- a/settings.json
+++ b/settings.json
@@ -16,7 +16,7 @@
   "top_p": 0.95,
   "min_p": 0.05,
   "repeat_penalty": 1.1,
-  "stop": ["<|start_header_id|>", "<|eot_id|>"],
+  "stop": ["<|eot_id|>"],
   "stream": false,
   "echo": false,
   "summarize_threshold": 20,


### PR DESCRIPTION
## Summary
- tweak default `stop` tokens so `<|start_header_id|>` is no longer used
- update `settings.json` to match the new stop token default

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684515877808832ba44bd1e2185faae5