### PR TITLE
Add response prompt busy indicator

### DIFF
--- a/MythForgeServer.py
+++ b/MythForgeServer.py
@@ -5,7 +5,7 @@ from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import StreamingResponse
 from fastapi.staticfiles import StaticFiles
 from queue import Queue
-from threading import Thread
+from threading import Thread, Lock
 from pydantic import BaseModel
 from typing import Dict, List
 
@@ -174,6 +174,8 @@ def call_llm(prompt: str, **kwargs):
 # follow-up prompts execute sequentially.
 
 RESPONSE_PROMPT_QUEUE: Queue = Queue()
+_RESP_PENDING = 0
+_RESP_LOCK = Lock()
 
 
 def _response_prompt_worker() -> None:
@@ -186,6 +188,8 @@ def _response_prompt_worker() -> None:
         except Exception as e:
             print(f"[response_prompt_queue] task failed: {e}")
         finally:
+            with _RESP_LOCK:
+                globals()['_RESP_PENDING'] = max(0, _RESP_PENDING - 1)
             RESPONSE_PROMPT_QUEUE.task_done()
 
 
@@ -195,6 +199,8 @@ _RESPONSE_PROMPT_THREAD.start()
 
 def enqueue_response_prompt(fn) -> None:
     """Add ``fn`` to the post-response processing queue."""
+    with _RESP_LOCK:
+        globals()['_RESP_PENDING'] += 1
     RESPONSE_PROMPT_QUEUE.put(fn)
 
 # ========== Helpers ==========
@@ -753,6 +759,14 @@ def update_settings(data: Dict[str, object]):
     global DEFAULT_MAX_TOKENS
     DEFAULT_MAX_TOKENS = SETTINGS.get("max_tokens", DEFAULT_MAX_TOKENS)
     return {"detail": "Updated", "settings": SETTINGS}
+
+# ========== Response Prompt Status ==========
+@app.get("/response_prompt_status")
+def response_prompt_status():
+    """Return the number of queued or running response prompts."""
+    with _RESP_LOCK:
+        pending = _RESP_PENDING
+    return {"pending": pending}
 
 # ========== Static UI Mount ==========
 app.mount("/", StaticFiles(directory=".", html=True), name="static")

--- a/MythForgeUI.html
+++ b/MythForgeUI.html
@@ -230,10 +230,11 @@
                             <polygon points="22 2 15 22 11 13 2 9 22 2"></polygon>
                         </svg>
                     </button>
-                    <button id="stop-button" class="send-button" style="display:none" title="Stop generation">
+                <button id="stop-button" class="send-button" style="display:none" title="Stop generation">
                         &#9632;
                     </button>
                 </div>
+                <div id="prompt-indicator" style="display:none; position:absolute; left:10px; bottom:8px; color:var(--primary); font-size:14px;">Processing...</div>
             </div>
         </div>
     </div>
@@ -294,7 +295,8 @@
                 min_p: 0.05,
                 repeat_penalty: 1.1
             },
-            isGenerating: false
+            isGenerating: false,
+            isProcessing: false
         };
 
         const chatContainer    = document.getElementById('chat-container');
@@ -304,6 +306,7 @@
         const stopButton       = document.getElementById('stop-button');
         let abortController    = null;
         let handleScroll       = null;
+        let promptCheckTimer   = null;
         const newChatButton    = document.getElementById('new-chat-btn');
         const historyContainer = document.getElementById('history-container');
        const themeSelect      = document.getElementById('theme-select');
@@ -334,6 +337,7 @@
         const chatSection      = document.getElementById('chat-section');
         const promptSection    = document.getElementById('prompt-section');
         const moreSection      = document.getElementById('more-section');
+        const promptIndicator  = document.getElementById('prompt-indicator');
 
        function applyTheme(name){
            document.body.setAttribute('data-theme', name);
@@ -832,6 +836,36 @@
         }
         function removeTyping(){ const t=document.getElementById('typing-indicator'); if(t) t.remove(); }
 
+        function updatePromptIndicator(){
+            const disabled = state.isGenerating || state.isProcessing;
+            sendButton.disabled = disabled;
+            sendOnlyButton.disabled = userInput.value.trim()==='' || disabled;
+            promptIndicator.style.display = state.isProcessing ? 'block' : 'none';
+        }
+
+        async function pollPromptStatus(){
+            try{
+                const res = await fetch('/response_prompt_status');
+                if(res.ok){
+                    const data = await res.json();
+                    if(data.pending===0){
+                        state.isProcessing = false;
+                        updatePromptIndicator();
+                        promptCheckTimer = null;
+                        return;
+                    }
+                }
+            }catch(e){ console.error('Status check failed:', e); }
+            promptCheckTimer = setTimeout(pollPromptStatus, 1000);
+        }
+
+        function startPromptMonitor(){
+            if(promptCheckTimer) return;
+            state.isProcessing = true;
+            updatePromptIndicator();
+            pollPromptStatus();
+        }
+
         async function sendMessage(allowEmpty=false){
             const text = userInput.value.trim();
             if(state.isGenerating || !state.currentChatId) return;
@@ -843,6 +877,7 @@
             stopButton.style.display='inline';
             if(text!=='') appendMessageToUI('user', text);
             addTyping(); state.isGenerating=true;
+            updatePromptIndicator();
             abortController = new AbortController();
             try{
                 const response = await fetch('/chat/stream', {
@@ -928,12 +963,12 @@
                     handleScroll = null;
                 }
                 state.isGenerating=false;
-                sendButton.disabled=state.isGenerating;
-                sendOnlyButton.disabled=userInput.value.trim()==='' || state.isGenerating;
+                updatePromptIndicator();
                 stopButton.style.display='none';
                 sendButton.style.display='inline';
                 sendOnlyButton.style.display='inline';
                 userInput.focus();
+                startPromptMonitor();
             }
         }
 
@@ -952,8 +987,7 @@
             }catch(err){
                 console.error('Send only failed:', err);
             }finally{
-                sendButton.disabled=state.isGenerating;
-                sendOnlyButton.disabled=userInput.value.trim()==='' || state.isGenerating;
+                updatePromptIndicator();
                 userInput.focus();
             }
         }
@@ -964,8 +998,7 @@
             stopButton.style.display="none";
             sendButton.style.display="inline";
             sendOnlyButton.style.display="inline";
-            sendButton.disabled=false;
-            sendOnlyButton.disabled=userInput.value.trim()==="";
+            updatePromptIndicator();
         }
 
         function setupEvents(){
@@ -986,7 +1019,7 @@
             sendOnlyButton.addEventListener('click', sendMessageNoGen);
             stopButton.addEventListener('click', stopGenerating);
             userInput.addEventListener('keydown', e=>{ if(e.key==='Enter' && !e.shiftKey){ e.preventDefault(); sendMessage(); } });
-            userInput.addEventListener('input', ()=>{ const disGen = state.isGenerating; sendButton.disabled = disGen; sendOnlyButton.disabled = userInput.value.trim()==='' || disGen; autoResize(); });
+            userInput.addEventListener('input', ()=>{ autoResize(); updatePromptIndicator(); });
             userInput.addEventListener('blur', ()=>{ setTimeout(scrollToBottom, 100); });
             newChatButton.addEventListener('click', startNewChat);
             newPromptBtn.addEventListener('click', addNewPrompt);
@@ -1008,6 +1041,7 @@
             await refreshGlobalPromptList();
             await loadServerSettings();
             autoResize();
+            updatePromptIndicator();
         })();
     </script>
 </body>


### PR DESCRIPTION
## Summary
- track queued response prompt tasks on the server and expose `/response_prompt_status`
- display a UI indicator while post-response prompts run
- lock message input until post-processing finishes

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684515fecb08832b9b785f290e44cc87