### PR TITLE
Improve goal evaluation parsing

### DIFF
--- a/tests/test_goal_tracker.py
+++ b/tests/test_goal_tracker.py
@@ -1,7 +1,12 @@
 import sys
 import os
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
-from goal_tracker import parse_and_merge_goals, GoalsListModel
+from goal_tracker import (
+    parse_and_merge_goals,
+    GoalsListModel,
+    format_goal_eval_response,
+    CHATS_DIR,
+)
 
 def test_duplicate_ids():
     state = {
@@ -20,4 +25,23 @@ def test_duplicate_ids():
     assert "1" not in ids
     assert "2" in ids
     assert "3" in ids
+
+
+def test_format_goal_eval_response_invalid(tmp_path, monkeypatch):
+    monkeypatch.setattr("goal_tracker.CHATS_DIR", tmp_path)
+    chat_id = "abc"
+    result = format_goal_eval_response("not json", chat_id)
+    assert result is None
+    error_path = tmp_path / f"{chat_id}_goal_eval_error.txt"
+    assert error_path.exists()
+    assert error_path.read_text() == "not json"
+
+
+def test_format_goal_eval_response_valid(tmp_path, monkeypatch):
+    monkeypatch.setattr("goal_tracker.CHATS_DIR", tmp_path)
+    chat_id = "good"
+    text = '{"goals": [{"id": "1", "description": "d", "method": "", "status": "completed"}]}'
+    result = format_goal_eval_response(text, chat_id)
+    assert result is not None
+    assert not (tmp_path / f"{chat_id}_goal_eval_error.txt").exists()
 


### PR DESCRIPTION
## Summary
- ensure invalid goal evaluation output is logged
- strengthen goal evaluation instructions
- add helper to parse goal evaluation
- test goal evaluation formatting helper

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68451b13b828832b9b986324079952c6