### PR TITLE
Implement automatic logging

### DIFF
--- a/MythForgeServer.py
+++ b/MythForgeServer.py
@@ -780,3 +780,8 @@ def response_prompt_status():
 # ========== Static UI Mount ==========
 app.mount("/", StaticFiles(directory=".", html=True), name="static")
 
+# Apply automatic logging to all functions in this module
+import sys
+from server_log import patch_module_functions
+patch_module_functions(sys.modules[__name__], "server")
+

--- a/airoboros_prompter.py
+++ b/airoboros_prompter.py
@@ -104,5 +104,11 @@ def main() -> None:
     print(result)
 
 
+# Apply automatic logging to all functions in this module
+import sys
+from server_log import patch_module_functions
+patch_module_functions(sys.modules[__name__], "formatting")
+
+
 if __name__ == "__main__":
     main()

--- a/goal_tracker.py
+++ b/goal_tracker.py
@@ -386,3 +386,8 @@ def state_as_prompt_fragment(state: Dict[str, Any]) -> str:
             lines.append(desc)
     return "\n".join(lines)
 
+# Apply automatic logging to all functions in this module
+import sys
+from server_log import patch_module_functions
+patch_module_functions(sys.modules[__name__], "goals system")
+

--- a/server_log.py
+++ b/server_log.py
@@ -1,0 +1,60 @@
+import os
+import json
+import datetime
+import atexit
+import functools
+import inspect
+
+LOG_DIR = "server_logs"
+os.makedirs(LOG_DIR, exist_ok=True)
+
+_log_data = []
+_log_file = os.path.join(LOG_DIR, f"{datetime.datetime.now().strftime('%Y%m%d_%H%M%S')}.json")
+
+
+def _flush():
+    with open(_log_file, 'w', encoding='utf-8') as f:
+        json.dump(_log_data, f, indent=2, ensure_ascii=False)
+
+atexit.register(_flush)
+
+
+def log_entry(tag: str, func: str, args, kwargs, result) -> None:
+    entry = {
+        "time": datetime.datetime.now().isoformat(),
+        "tag": tag,
+        "function": func,
+        "args": repr(args),
+        "kwargs": repr(kwargs),
+        "result": repr(result),
+    }
+    _log_data.append(entry)
+
+
+def log_function(tag: str):
+    def decorator(fn):
+        @functools.wraps(fn)
+        def wrapper(*args, **kwargs):
+            try:
+                res = fn(*args, **kwargs)
+                log_entry(tag, fn.__name__, args, kwargs, res)
+                return res
+            except Exception as e:
+                log_entry(tag, fn.__name__, args, kwargs, f"ERROR: {e}")
+                raise
+        wrapper._patched = True
+        return wrapper
+    return decorator
+
+
+def patch_module_functions(module, tag: str) -> None:
+    for name, func in inspect.getmembers(module, inspect.isfunction):
+        if func.__module__ != module.__name__:
+            continue
+        if getattr(func, "_patched", False):
+            continue
+        setattr(module, name, log_function(tag)(func))
+
+
+def get_log_path() -> str:
+    return _log_file


### PR DESCRIPTION
## Summary
- add new `server_log` module for server-wide JSON logs
- enable automatic logging for MythForgeServer, goal tracker and formatter

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6845b771fc28832bb9a56f2fdd182220