### PR TITLE
Fix logging not flushing

### DIFF
--- a/server_log.py
+++ b/server_log.py
@@ -29,6 +29,10 @@ def log_entry(tag: str, func: str, args, kwargs, result) -> None:
         "result": repr(result),
     }
     _log_data.append(entry)
+    # Immediately persist logs so the file exists even if the process
+    # is long-running.  This ensures that a log file is created as soon
+    # as the first entry is recorded instead of only on shutdown.
+    _flush()
 
 
 def log_function(tag: str):


### PR DESCRIPTION
## Summary
- flush the log file after every log entry to ensure a log exists while the server is running

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6845bbd1d534832b9368c5fdf4561cc1