### PR TITLE
Fix goal initialization sequence

### DIFF
--- a/MythForgeServer.py
+++ b/MythForgeServer.py
@@ -462,8 +462,6 @@ def build_prompt(chat_id, user_message, global_prompt_name):
 
     # Incorporate character state and goals if available
     state = load_state(chat_id)
-    check_and_generate_goals(call_llm, chat_id)
-    state = load_state(chat_id)
     fragment = state_as_prompt_fragment(state)
     if fragment:
         system_prompt = system_prompt + "\n" + fragment


### PR DESCRIPTION
## Summary
- extract scene context and character profile from the first exchange
- generate goals only after initial state is established
- simplify state prompt fragments
- remove pre-response goal generation in `build_prompt`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6845cacc5a88832b91997f2b8165164d