### PR TITLE
Limit goal generation retries

### DIFF
--- a/goal_tracker.py
+++ b/goal_tracker.py
@@ -243,7 +243,7 @@ def check_and_generate_goals(call_fn, chat_id: str) -> None:
     # Log full prompt for debugging before sending to the LLM
     logger.info("LLM goal prompt", extra={"chat_id": chat_id, "prompt": prompt})
 
-    for attempt in range(1, 4):
+    for attempt in range(1, 3):
         output = call_fn(prompt, max_tokens=200)
         text = output["choices"][0]["text"].strip()
         logger.debug(
@@ -266,7 +266,7 @@ def check_and_generate_goals(call_fn, chat_id: str) -> None:
             )
 
     logger.warning(
-        "Goal generation failed after 3 attempts",
+        "Goal generation failed after 2 attempts",
         extra={"chat_id": chat_id}
     )
 

--- a/tests/test_goal_tracker.py
+++ b/tests/test_goal_tracker.py
@@ -133,5 +133,5 @@ def test_check_and_generate_goals_retry_failure(tmp_path, monkeypatch):
     new_state = json.loads((tmp_path / chat_id / "state.json").read_text())
     assert new_state["goals"] == []
     assert new_state["messages_since_goal_eval"] == 5
-    assert calls["n"] == 3
+    assert calls["n"] == 2
 


### PR DESCRIPTION
## Summary
- reduce `check_and_generate_goals` retry loop from three to two attempts
- update unit test for the new retry count

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6845e60b6cc8832b9914d70d23a81753