### PR TITLE
Add logging for goal LLM raw output

### DIFF
--- a/goal_tracker.py
+++ b/goal_tracker.py
@@ -246,6 +246,7 @@ def check_and_generate_goals(call_fn, chat_id: str) -> None:
     for attempt in range(1, 3):
         output = call_fn(prompt, max_tokens=200)
         text = output["choices"][0]["text"].strip()
+        log_event("goals_llm_raw", {"raw": text})
         logger.debug(
             "Goal generation attempt %d raw output:\n%s",
             attempt,
@@ -259,6 +260,7 @@ def check_and_generate_goals(call_fn, chat_id: str) -> None:
             save_state(chat_id, state)
             return
         else:
+            log_event("goals_parse_failed", {"raw": text})
             logger.warning(
                 "Goal parsing returned no results on attempt %d",
                 attempt,
@@ -453,6 +455,6 @@ def state_as_prompt_fragment(state: Dict[str, Any]) -> str:
 
 # Apply automatic logging to all functions in this module
 import sys
-from server_log import patch_module_functions
+from server_log import patch_module_functions, log_event
 patch_module_functions(sys.modules[__name__], "goals system")
 

--- a/server_log.py
+++ b/server_log.py
@@ -4,6 +4,7 @@ import datetime
 import atexit
 import functools
 import inspect
+from typing import Any, Dict
 
 LOG_DIR = "server_logs"
 os.makedirs(LOG_DIR, exist_ok=True)
@@ -51,6 +52,12 @@ def log_entry(tag: str, func, args, kwargs, result) -> None:
     # Immediately persist logs so the file exists even if the process
     # is long-running.  This ensures that a log file is created as soon
     # as the first entry is recorded instead of only on shutdown.
+    _flush()
+
+
+def log_event(tag: str, data: Dict[str, Any]) -> None:
+    entry = {"time": datetime.datetime.now().isoformat(), "tag": tag, **data}
+    _log_data.append(entry)
     _flush()
 
 


### PR DESCRIPTION
## Summary
- log raw LLM text before parsing goals and when parsing fails
- expose a `log_event` helper in `server_log`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6845eae36d6c832b8b8451ac942fe6b6