### PR TITLE
UI tweak: show message menu icon permanently

### DIFF
--- a/MythForgeUI.html
+++ b/MythForgeUI.html
@@ -145,8 +145,7 @@
         .user-avatar { background-color: var(--user-msg-bg); color: var(--user-msg-color); }
         .ai-avatar { background-color: var(--primary); color: white; }
         .message-content { flex-grow: 1; max-width: none; line-height: 1.6; font-size: var(--message-font-size); }
-        .message-control-btn { position: absolute; bottom: 4px; right: 4px; background: none; border: none; cursor: pointer; color: var(--text-color); display: none; }
-        .message:hover .message-control-btn { display: block; }
+        .message-control-btn { position: absolute; bottom: 4px; right: 4px; background: none; border: none; cursor: pointer; color: var(--text-color); display: block; }
         .message-menu { position: absolute; bottom: 28px; right: 4px; background: var(--bg-color); border: 1px solid var(--border-color); border-radius: 4px; box-shadow: 0 2px 4px rgba(0,0,0,0.2); display: flex; flex-direction: column; z-index: 100; }
         .message-menu button { background: none; border: none; padding: 6px 12px; cursor: pointer; font-size: 14px; text-align: left; color: var(--text-color); }
         .message-menu button:hover { background-color: var(--hover-color); }


### PR DESCRIPTION
## Summary
- update CSS so message options icon is visible without hover

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684621c56f10832b8bde2061bd182582