### PR TITLE
Append goals in parse_goals_from_response

### DIFF
--- a/tests/test_goal_tracker.py
+++ b/tests/test_goal_tracker.py
@@ -313,3 +313,14 @@ def test_preserve_goal_details_on_completion(tmp_path, monkeypatch):
     assert new_state["goals"] == []
     assert new_state["completed_goals"] == [{"id": "1", "description": "orig", "method": "m", "status": "completed"}]
 
+
+def test_parse_goals_from_response_appends():
+    existing = [{"id": "1", "description": "a", "method": ""}]
+    text = '[{"id": "2", "description": "b", "method": ""}]'
+    result = goal_tracker.parse_goals_from_response(text, existing)
+    assert result is existing
+    assert existing == [
+        {"id": "1", "description": "a", "method": ""},
+        {"id": "2", "description": "b", "method": ""},
+    ]
+


### PR DESCRIPTION
## Summary
- update `parse_goals_from_response` to optionally append to an existing goal list
- add unit test covering append behaviour

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684629f3ccb8832ba0b2599c2109e30f