### PR TITLE
Improve goal merging logic

### DIFF
--- a/tests/test_goal_tracker.py
+++ b/tests/test_goal_tracker.py
@@ -322,7 +322,9 @@ def test_preserve_goal_details_on_completion(tmp_path, monkeypatch):
     evaluate_and_update_goals(fake_call, chat_id, min_active=1)
     new_state = json.loads((tmp_path / chat_id / "state.json").read_text())
     assert new_state["goals"] == []
-    assert new_state["completed_goals"] == [{"id": "1", "description": "orig", "method": "m", "status": "completed"}]
+    assert new_state["completed_goals"] == [
+        {"id": "1", "description": "changed", "method": "x", "status": "completed"}
+    ]
 
 
 def test_parse_goals_from_response_appends():


### PR DESCRIPTION
## Summary
- enhance `save_state` to avoid unnecessary writes
- add helpers `_merge_goals` and `_apply_goal_update` for merging goal info
- merge incoming goals instead of overwriting during generation and evaluation
- log detailed changes to goals
- update tests for new merging behaviour

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68463730c2e8832b8689951c13c6666c