### PR TITLE
Optimize server logging

### DIFF
--- a/server_log.py
+++ b/server_log.py
@@ -14,8 +14,14 @@ _log_file = os.path.join(LOG_DIR, f"{datetime.datetime.now().strftime('%Y%m%d_%H
 
 
 def _flush():
-    with open(_log_file, 'w', encoding='utf-8') as f:
-        json.dump(_log_data, f, indent=2, ensure_ascii=False)
+    """Append buffered log entries to the log file in JSONL format."""
+    if not _log_data:
+        return
+    with open(_log_file, 'a', encoding='utf-8') as f:
+        for entry in _log_data:
+            f.write(json.dumps(entry, ensure_ascii=False))
+            f.write("\n")
+    _log_data.clear()
 
 atexit.register(_flush)
 
@@ -49,9 +55,7 @@ def log_entry(tag: str, func, args, kwargs, result) -> None:
         "result": repr(result),
     }
     _log_data.append(entry)
-    # Immediately persist logs so the file exists even if the process
-    # is long-running.  This ensures that a log file is created as soon
-    # as the first entry is recorded instead of only on shutdown.
+    # Persist immediately so the file exists even if the process runs long.
     _flush()
 
 

--- a/tests/test_goal_tracker.py
+++ b/tests/test_goal_tracker.py
@@ -67,7 +67,7 @@ def test_format_goal_eval_response_invalid(tmp_path, monkeypatch):
     result = format_goal_eval_response("not json", chat_id)
     assert result is None
 
-    data = json.loads(log_path.read_text())
+    data = [json.loads(line) for line in log_path.read_text().splitlines()]
     assert any(e.get("tag") == "goal_eval_invalid_output" and e.get("raw") == "not json" for e in data)
 
 
@@ -82,7 +82,7 @@ def test_format_goal_eval_response_valid(tmp_path, monkeypatch):
     result = format_goal_eval_response(text, chat_id)
     assert result is not None
 
-    data = json.loads(log_path.read_text())
+    data = [json.loads(line) for line in log_path.read_text().splitlines()]
     assert not any(e.get("tag") == "goal_eval_invalid_output" for e in data)
 
 


### PR DESCRIPTION
## Summary
- use JSONL format and append new entries to log
- parse JSON lines in server log tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68464cb6c61c832ba6ad238ddcc36127