### PR TITLE
Log file uses session id

### DIFF
--- a/server_log.py
+++ b/server_log.py
@@ -1,6 +1,7 @@
 import os
 import json
 import datetime
+import uuid
 import atexit
 import functools
 import inspect
@@ -10,7 +11,8 @@ LOG_DIR = "server_logs"
 os.makedirs(LOG_DIR, exist_ok=True)
 
 _log_data = []
-_log_file = os.path.join(LOG_DIR, f"{datetime.datetime.now().strftime('%Y%m%d_%H%M%S')}.json")
+_session_id = os.environ.get("MF_SESSION_ID") or uuid.uuid4().hex
+_log_file = os.path.join(LOG_DIR, f"{_session_id}.json")
 
 
 def _flush():


### PR DESCRIPTION
## Summary
- base server log name on `MF_SESSION_ID` env var or a generated uuid

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68464e93083c832ba07da0ee5c656e61