### PR TITLE
Add function name to server logs

### DIFF
--- a/server_log.py
+++ b/server_log.py
@@ -49,6 +49,7 @@ def _get_function_details(fn):
 
 def log_entry(tag: str, func, args, kwargs, result) -> None:
     entry = {
+        "function_name": func.__name__,
         "time": datetime.datetime.now().isoformat(),
         "tag": tag,
         "function": _get_function_details(func),
@@ -62,7 +63,14 @@ def log_entry(tag: str, func, args, kwargs, result) -> None:
 
 
 def log_event(tag: str, data: Dict[str, Any]) -> None:
-    entry = {"time": datetime.datetime.now().isoformat(), "tag": tag, **data}
+    caller = inspect.currentframe().f_back
+    func_name = caller.f_code.co_name if caller else "<unknown>"
+    entry = {
+        "function_name": func_name,
+        "time": datetime.datetime.now().isoformat(),
+        "tag": tag,
+        **data,
+    }
     _log_data.append(entry)
     _flush()
 

--- a/tests/test_server_log.py
+++ b/tests/test_server_log.py
@@ -1,0 +1,36 @@
+import json
+import os
+import server_log
+
+
+def test_log_event_includes_function_name(tmp_path, monkeypatch):
+    log_path = tmp_path / "log.json"
+    monkeypatch.setattr(server_log, "_log_file", str(log_path))
+    server_log._log_data.clear()
+
+    def sample():
+        server_log.log_event("test_tag", {"a": 1})
+
+    sample()
+
+    data = [json.loads(line) for line in log_path.read_text().splitlines()]
+    entry = data[0]
+    assert entry["function_name"] == "sample"
+    assert entry["tag"] == "test_tag"
+
+
+def test_log_function_includes_function_name(tmp_path, monkeypatch):
+    log_path = tmp_path / "log_func.json"
+    monkeypatch.setattr(server_log, "_log_file", str(log_path))
+    server_log._log_data.clear()
+
+    @server_log.log_function("decorated")
+    def foo(x):
+        return x * 2
+
+    foo(3)
+
+    data = [json.loads(line) for line in log_path.read_text().splitlines()]
+    entry = data[0]
+    assert entry["function_name"] == "foo"
+    assert entry["tag"] == "decorated"


### PR DESCRIPTION
## Summary
- store the caller's name in `log_event` entries
- include the wrapped function's name in `log_entry`
- add tests for the new server logging behavior

## Testing
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684657da9fe8832bb1db74281480fb21