### PR TITLE
Limit goal generation to MAX_GOALS

### DIFF
--- a/goal_tracker.py
+++ b/goal_tracker.py
@@ -367,8 +367,9 @@ def check_and_generate_goals(call_fn, chat_id: str) -> None:
         logger.debug("Character state incomplete", extra={"chat_id": chat_id})
         return
     instruction = (
-        "Based on the character profile and scene context, generate 2 to 3 specific, "
-        "actionable goals for the character along with a short plan to achieve each. "
+        "Based on the character profile and scene context, generate 2 to "
+        f"{MAX_GOALS} specific, actionable goals for the character along "
+        "with a short plan to achieve each. "
         "Return ONLY JSON like: {\"goals\": [{\"description\": \"...\", \"method\": \"...\"}]}."
     )
     messages = [


### PR DESCRIPTION
## Summary
- ensure goal generation prompt uses configured MAX_GOALS

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68466d5fcc04832b95b2798617670272