### PR TITLE
Fix goal generation temperature

### DIFF
--- a/goal_tracker.py
+++ b/goal_tracker.py
@@ -386,7 +386,7 @@ def check_and_generate_goals(call_fn, chat_id: str) -> None:
     log_event("llm_final_prompt", {"prompt": prompt})
 
     for attempt in range(1, 3):
-        output = call_fn(prompt, max_tokens=200)
+        output = call_fn(prompt, max_tokens=200, temperature=0)
         text = output["choices"][0]["text"].strip()
         log_event("goals_llm_raw", {"raw": text})
         logger.debug(

--- a/tests/test_goal_tracker.py
+++ b/tests/test_goal_tracker.py
@@ -109,7 +109,7 @@ def test_check_and_generate_goals_resets_counter(tmp_path, monkeypatch):
     with open(tmp_path / chat_id / "state.json", "w", encoding="utf-8") as f:
         json.dump(state, f)
 
-    def fake_call(_prompt, max_tokens=200):
+    def fake_call(_prompt, max_tokens=200, **kwargs):
         return {"choices": [{"text": '[{"description":"d","method":"plan"}]'}]}
 
     goal_tracker.check_and_generate_goals(fake_call, chat_id)
@@ -133,7 +133,7 @@ def test_check_and_generate_goals_retry_success(tmp_path, monkeypatch):
 
     calls = {"n": 0}
 
-    def fake_call(_prompt, max_tokens=200):
+    def fake_call(_prompt, max_tokens=200, **kwargs):
         calls["n"] += 1
         if calls["n"] < 2:
             return {"choices": [{"text": "[]"}]}
@@ -161,7 +161,7 @@ def test_check_and_generate_goals_retry_failure(tmp_path, monkeypatch):
 
     calls = {"n": 0}
 
-    def fake_call(_prompt, max_tokens=200):
+    def fake_call(_prompt, max_tokens=200, **kwargs):
         calls["n"] += 1
         return {"choices": [{"text": "[]"}]}
 


### PR DESCRIPTION
## Summary
- force goal generation calls to use zero temperature
- adjust tests for updated call signature

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6846760449ec832ba1c6ad0444c7eb3c