### PR TITLE
Normalize goal status values

### DIFF
--- a/goal_tracker.py
+++ b/goal_tracker.py
@@ -185,12 +185,15 @@ def _parse_goal_items(text: str) -> List[Dict[str, Any]]:
         if isinstance(data, list):
             for entry in data:
                 if isinstance(entry, dict):
+                    status = entry.get("status")
+                    if isinstance(status, str):
+                        status = status.strip().lower()
                     goal = {
                         "id": entry.get("id"),
                         "description": entry.get("description")
                         or entry.get("text", ""),
                         "method": entry.get("method", ""),
-                        "status": entry.get("status"),
+                        "status": status,
                     }
                     if goal["description"] or goal["id"]:
                         items.append(goal)
@@ -591,11 +594,8 @@ def evaluate_and_update_goals(
                     goal_data[field] = ""
 
             status = (
-                g.status
-                if g.status is not None
-                else goal_data.get("status")
-                or "in_progress"
-            ).lower()
+                (g.status or goal_data.get("status") or "in_progress").strip().lower()
+            )
             goal_data["status"] = status
 
             desc_key = goal_data.get("description", "").lower()

--- a/tests/test_goal_tracker.py
+++ b/tests/test_goal_tracker.py
@@ -364,3 +364,40 @@ def test_parse_goals_from_response_appends():
         {"description": "b", "method": ""},
     ]
 
+
+def test_status_trailing_space(tmp_path, monkeypatch):
+    monkeypatch.setattr("goal_tracker.CHATS_DIR", tmp_path)
+    chat_id = "trail"
+    state = {
+        "completed_goals": [],
+        "goals": [{"id": "1", "description": "goal", "method": "", "status": "in_progress"}],
+        "messages_since_goal_eval": 4,
+        "character_profile": "c",
+        "scene_context": "s",
+    }
+    os.makedirs(tmp_path / chat_id, exist_ok=True)
+    with open(tmp_path / chat_id / "state.json", "w", encoding="utf-8") as f:
+        json.dump(state, f)
+    with open(tmp_path / chat_id / "trimmed.json", "w", encoding="utf-8") as f:
+        json.dump([], f)
+
+    def fake_call(_prompt, max_tokens=300):
+        return {
+            "choices": [
+                {
+                    "text": json.dumps({"goals": [
+                        {"id": "1", "description": "goal", "method": "", "status": "Completed "}
+                    ]})
+                }
+            ]
+        }
+
+    monkeypatch.setattr("goal_tracker.check_and_generate_goals", lambda *a, **k: None)
+
+    evaluate_and_update_goals(fake_call, chat_id, min_active=1)
+    new_state = json.loads((tmp_path / chat_id / "state.json").read_text())
+    assert new_state["goals"] == []
+    assert new_state["completed_goals"] == [
+        {"id": "1", "description": "goal", "method": "", "status": "completed"}
+    ]
+


### PR DESCRIPTION
## Summary
- normalize statuses when parsing goals
- ensure evaluate/update uses consistent status formatting
- test status normalization of trailing spaces

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68469e420cc4832bbf7ace06e2ed97c2