### PR TITLE
Fix call_llm return type

### DIFF
--- a/MythForgeServer.py
+++ b/MythForgeServer.py
@@ -184,15 +184,18 @@ def call_llm(prompt: str, **kwargs):
         filtered = kwargs
 
     if filtered.get("stream"):
-        for chunk in llm(prompt, **filtered):
-            text = chunk["choices"][0]["text"]
-            log_event("llm_raw_output", {"raw": text})
-            yield chunk
-    else:
-        res = llm(prompt, **filtered)
-        text = res["choices"][0]["text"]
-        log_event("llm_raw_output", {"raw": text})
-        return res
+        def _stream():
+            for chunk in llm(prompt, **filtered):
+                text = chunk["choices"][0]["text"]
+                log_event("llm_raw_output", {"raw": text})
+                yield chunk
+
+        return _stream()
+
+    res = llm(prompt, **filtered)
+    text = res["choices"][0]["text"]
+    log_event("llm_raw_output", {"raw": text})
+    return res
 
 call_llm._patched = True
 

--- a/tests/test_call_llm.py
+++ b/tests/test_call_llm.py
@@ -1,0 +1,34 @@
+import os
+import sys
+import types
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+# Provide a minimal stub for llama_cpp to avoid loading a real model
+sys.modules.setdefault("llama_cpp", types.SimpleNamespace(Llama=lambda **k: None))
+
+import MythForgeServer
+
+class Dummy:
+    def __init__(self, outputs):
+        self.outputs = outputs
+
+    def __call__(self, prompt, **kwargs):
+        if kwargs.get("stream"):
+            return ({"choices": [{"text": o}]} for o in self.outputs)
+        return {"choices": [{"text": self.outputs[0]}]}
+
+def test_call_llm_non_stream(monkeypatch):
+    monkeypatch.setattr(MythForgeServer, "llm", Dummy(["hello"]))
+    res = MythForgeServer.call_llm("hi")
+    assert isinstance(res, dict)
+    assert res["choices"][0]["text"] == "hello"
+
+def test_call_llm_stream(monkeypatch):
+    monkeypatch.setattr(MythForgeServer, "llm", Dummy(["a", "b"]))
+    gen = MythForgeServer.call_llm("hi", stream=True)
+    assert list(gen) == [
+        {"choices": [{"text": "a"}]},
+        {"choices": [{"text": "b"}]},
+    ]
+


### PR DESCRIPTION
## Summary
- ensure `call_llm` only returns a generator when streaming
- add unit test for `call_llm` stream and non-stream behavior

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6846ac4efea0832b9104a5f1b8383974