### PR TITLE
Improve state logging

### DIFF
--- a/MythForgeServer.py
+++ b/MythForgeServer.py
@@ -6,6 +6,7 @@ from fastapi.responses import StreamingResponse
 from fastapi.staticfiles import StaticFiles
 from queue import Queue
 from threading import Thread, Lock
+from server_log import log_function
 from pydantic import BaseModel
 from typing import Dict, List
 
@@ -453,6 +454,7 @@ def trim_context(chat_id):
 
     return history
 
+@log_function("state_writer_caller")
 def build_prompt(chat_id, user_message, global_prompt_name):
     """Construct the next prompt using the LLaMA3 header-token format."""
 
@@ -623,6 +625,7 @@ def rename_chat(chat_id: str, data: Dict[str, str]):
     return {"detail": f"Renamed chat '{chat_id}' to '{new_id}'"}
 
 @app.post("/chat")
+@log_function("state_writer_caller")
 def chat(req: ChatRequest):
     chat_id       = req.chat_id
     user_message  = req.message
@@ -684,6 +687,7 @@ def chat(req: ChatRequest):
 
 # ─── Streaming Chat Endpoint with Prompt JSON Prefix ────────────────────────
 @app.post("/chat/stream")
+@log_function("state_writer_caller")
 def chat_stream(req: ChatRequest):
     """
     Streams tokens as the model generates them.
@@ -712,6 +716,7 @@ def chat_stream(req: ChatRequest):
     # build_prompt() already saved the user's message to both history files,
     # so we can immediately begin streaming the model's response.
 
+    @log_function("state_writer_caller")
     def generate_and_stream():
         # First, send a single line of JSON with the prompt:
         meta = json.dumps({"prompt": prompt}, ensure_ascii=False)
@@ -799,6 +804,7 @@ def chat_stream(req: ChatRequest):
 
 # ─── Endpoint: Log Message Without Generating ------------------------------
 @app.post("/message")
+@log_function("state_writer_caller")
 def log_message(req: ChatRequest):
     """Record a user message without generating a response."""
 

--- a/goal_tracker.py
+++ b/goal_tracker.py
@@ -1,6 +1,7 @@
 # Goal tracking utilities for Myth Forge
 import json
 import logging
+from server_log import log_function
 import os
 import re
 import time
@@ -101,6 +102,7 @@ def load_state(chat_id: str) -> Dict[str, Any]:
     }
 
 
+@log_function("state_writer")
 def save_state(chat_id: str, state: Dict[str, Any]) -> bool:
     """Persist ``state`` to disk if it differs from the existing file.
 
@@ -142,6 +144,7 @@ def extract_character_profile(text: str) -> str:
     return text.strip()
 
 
+@log_function("state_writer")
 def init_state_from_prompt(chat_id: str, global_prompt: str, first_user: str) -> None:
     """Initialize state using ``global_prompt`` and ``first_user`` if unset."""
     logger.info("Initializing state from prompt", extra={"chat_id": chat_id})
@@ -154,6 +157,7 @@ def init_state_from_prompt(chat_id: str, global_prompt: str, first_user: str) ->
         log_event("state_saved", {"path": _state_path(chat_id)})
 
 
+@log_function("state_writer")
 def ensure_initial_state(call_fn, chat_id: str, global_prompt: str, first_user: str, first_assistant: str) -> None:
     """Populate ``scene_context`` and ``character_profile`` from the first exchange."""
     logger.info("Ensuring initial state", extra={"chat_id": chat_id})
@@ -410,6 +414,7 @@ def _check_goal_similarity(
         log_event("goal_similarity_parse_failed", {"raw": text})
     return False
 
+@log_function("state_writer")
 def check_and_generate_goals(call_fn, chat_id: str) -> None:
     """Generate goals if none exist using current state."""
     logger.info("Checking for missing goals", extra={"chat_id": chat_id})
@@ -542,6 +547,7 @@ def format_goal_eval_response(text: str, chat_id: str) -> Optional[GoalsListMode
     return None
 
 
+@log_function("state_writer")
 def evaluate_and_update_goals(
     call_fn,
     chat_id: str,
@@ -681,6 +687,7 @@ def evaluate_and_update_goals(
         log_event("state_saved", {"path": _state_path(chat_id)})
 
 
+@log_function("state_writer")
 def record_user_message(chat_id: str) -> None:
     """Increment the message counter for ``chat_id``."""
     state = load_state(chat_id)
@@ -689,6 +696,7 @@ def record_user_message(chat_id: str) -> None:
         log_event("state_saved", {"path": _state_path(chat_id)})
 
 
+@log_function("state_writer")
 def record_assistant_message(chat_id: str) -> bool:
     """Increment the counter and return True when goal evaluation should run."""
     state = load_state(chat_id)


### PR DESCRIPTION
## Summary
- add `log_function` decorator import for use across modules
- decorate state-writing helpers in `goal_tracker` to label them as `state_writer`
- decorate server endpoints and helpers that call state-writing functions with `state_writer_caller`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6846b1ae1cc0832ba51faa5fe711d8d6