### PR TITLE
Fix RunMythForge.bat server path

### DIFF
--- a/RunMythForge.bat
+++ b/RunMythForge.bat
@@ -1,3 +1,3 @@
 @echo off
 cd /d "%~dp0"
-py -m uvicorn MythForgeServer:app --host 0.0.0.0 --port 8000 --reload
+py -m uvicorn scripts.MythForgeServer:app --host 0.0.0.0 --port 8000 --reload


### PR DESCRIPTION
## Summary
- fix path to MythForgeServer in RunMythForge.bat

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68472c14fd14832bbc041af655550bc7