### PR TITLE
Add stub endpoints for UI

### DIFF
--- a/scripts/disable.py
+++ b/scripts/disable.py
@@ -1,0 +1,16 @@
+"""Utility stubs for logging and patching."""
+
+from types import ModuleType
+from typing import Callable
+
+
+def patch_module_functions(module: ModuleType, _name: str) -> None:
+    """Dummy patcher that leaves ``module`` untouched."""
+
+    return None
+
+
+def log_event(event: str, data: dict) -> None:
+    """Print a log message for ``event`` with ``data``."""
+
+    print(f"{event}: {data}")


### PR DESCRIPTION
## Summary
- implement ChatRequest model and placeholder chat endpoints
- provide stub disable module

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_6847491f8254832bb2040a037b281fb6