### PR TITLE
Fix missing import and load model

### DIFF
--- a/scripts/MythForgeServer.py
+++ b/scripts/MythForgeServer.py
@@ -4,6 +4,9 @@ from typing import Dict, List
 
 from fastapi import FastAPI, HTTPException
 from fastapi.responses import StreamingResponse
+from fastapi.staticfiles import StaticFiles
+
+from . import model_launch
 from pydantic import BaseModel
 
 app = FastAPI(title="Myth Forge Server")
@@ -138,9 +141,7 @@ def delete_global_prompt(name: str):
 def list_chats():
     os.makedirs(CHATS_DIR, exist_ok=True)
     chat_ids = [
-        d
-        for d in os.listdir(CHATS_DIR)
-        if os.path.isdir(os.path.join(CHATS_DIR, d))
+        d for d in os.listdir(CHATS_DIR) if os.path.isdir(os.path.join(CHATS_DIR, d))
     ]
     return {"chats": chat_ids}
 


### PR DESCRIPTION
## Summary
- include StaticFiles and model_launch imports in MythForgeServer
- format MythForgeServer with `black`

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68474b380eb4832b90bb19cc1dec13b6