### PR TITLE
Add model calling utilities

### DIFF
--- a/scripts/model_call.py
+++ b/scripts/model_call.py
@@ -1,0 +1,40 @@
+"""Utilities for formatting prompts and calling the language model."""
+
+from __future__ import annotations
+
+from typing import Dict, Iterable, List
+
+from . import model_launch
+
+
+def build_prompt(
+    messages: List[Dict[str, str]], global_prompt: str | None = None
+) -> str:
+    """Return a prompt string for the model."""
+
+    parts: List[str] = []
+    if global_prompt:
+        parts.append(global_prompt.strip())
+    for msg in messages:
+        role = msg.get("role", "user").upper()
+        content = msg.get("content", "").strip()
+        parts.append(f"{role}: {content}")
+    parts.append("ASSISTANT:")
+    return "\n".join(parts)
+
+
+def call_model(
+    messages: List[Dict[str, str]],
+    *,
+    global_prompt: str | None = None,
+    stream: bool | None = None,
+) -> Iterable[Dict[str, object]]:
+    """Build a prompt and send it to the model via ``call_llm``."""
+
+    prompt = build_prompt(messages, global_prompt)
+    kwargs: Dict[str, object] = model_launch.GENERATION_CONFIG.copy()
+    if stream is not None:
+        kwargs["stream"] = stream
+    else:
+        kwargs["stream"] = model_launch.MODEL_SETTINGS.get("stream", False)
+    return model_launch.call_llm(prompt, **kwargs)

--- a/scripts/model_response.py
+++ b/scripts/model_response.py
@@ -1,0 +1,26 @@
+"""Utilities for parsing and cleaning model responses."""
+
+from __future__ import annotations
+
+from typing import Iterable, Iterator
+
+
+def clean_text(text: str) -> str:
+    """Return ``text`` stripped of whitespace and known tokens."""
+
+    cleaned = text.replace("<|eot_id|>", "").strip()
+    return cleaned
+
+
+def parse_response(output: dict) -> str:
+    """Extract and clean the text portion from a model call result."""
+
+    text = output.get("choices", [{}])[0].get("text", "")
+    return clean_text(text)
+
+
+def stream_parsed(chunks: Iterable[dict]) -> Iterator[str]:
+    """Yield cleaned text from a streaming model call."""
+
+    for chunk in chunks:
+        yield clean_text(chunk.get("choices", [{}])[0].get("text", ""))


### PR DESCRIPTION
## Summary
- add `model_call.py` to build prompts and invoke the model
- add `model_response.py` to parse and clean model output

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68475f56d010832ba9300544c93068e3