### PR TITLE
Integrate model call via tagged prompts

### DIFF
--- a/scripts/model_call.py
+++ b/scripts/model_call.py
@@ -38,3 +38,25 @@ def call_model(
     else:
         kwargs["stream"] = model_launch.MODEL_SETTINGS.get("stream", False)
     return model_launch.call_llm(prompt, **kwargs)
+
+
+def call_tagged(
+    system_text: str, user_text: str, *, stream: bool | None = None
+) -> Iterable[Dict[str, object]]:
+    """Call the model using the header-tagged prompt format."""
+
+    prompt = (
+        "<|start_header_id|>system<|end_header_id|>\n"
+        f"{system_text}\n"
+        "<|eot_id|>\n"
+        "<|start_header_id|>user<|end_header_id|>\n"
+        f"{user_text}\n"
+        "<|eot_id|>\n"
+        "<|start_header_id|>assistant<|end_header_id|>\n"
+    )
+    kwargs: Dict[str, object] = model_launch.GENERATION_CONFIG.copy()
+    if stream is not None:
+        kwargs["stream"] = stream
+    else:
+        kwargs["stream"] = model_launch.MODEL_SETTINGS.get("stream", False)
+    return model_launch.call_llm(prompt, **kwargs)


### PR DESCRIPTION
## Summary
- add `call_tagged` helper for header-tagged prompts
- stream and store responses in `chat_stream`
- support normal chat replies using the model

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_684783a2f504832ba2d8bdb0f37fa9b2