### PR TITLE
Fix delete button order in message menu

### DIFF
--- a/ui/MythForgeUI.html
+++ b/ui/MythForgeUI.html
@@ -970,7 +970,7 @@
             editBtn.onclick=(e)=>{ e.stopPropagation(); closeMessageMenu(); editMessage(idx,current); };
             const delBtn=document.createElement('button');
             delBtn.textContent='Delete';
-            delBtn.onclick=(e)=>{ e.stopPropagation(); closeMessageMenu(); deleteMessage(idx); };
+            delBtn.onclick=(e)=>{ e.stopPropagation(); deleteMessage(idx); closeMessageMenu(); };
             menu.appendChild(editBtn); menu.appendChild(delBtn);
             div.appendChild(menu);
             activeMenu = menu;


### PR DESCRIPTION
## Summary
- ensure the Delete option in the message context menu executes its delete function before the menu closes

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6847845e6ad4832b9ae27a6cf246cf41