### PR TITLE
Remove extra prompt rename dialog

### DIFF
--- a/scripts/MythForgeServer.py
+++ b/scripts/MythForgeServer.py
@@ -282,6 +282,10 @@ def rename_prompt(name: str, data: Dict[str, str]):
     new_name = data.get("new_name", "").strip()
     if not new_name:
         raise HTTPException(status_code=400, detail="New name required")
+
+    if new_name == name:
+        return {"detail": f"Renamed prompt '{name}'"}
+
     save_item("prompts", name, new_name=new_name)
     return {"detail": f"Renamed prompt '{name}'"}
 

--- a/ui/MythForgeUI.html
+++ b/ui/MythForgeUI.html
@@ -906,23 +906,7 @@
         }
 
         async function renamePrompt(oldName){
-            promptText('Enter new prompt name:', oldName, async (trimmed)=>{
-                if(trimmed.toLowerCase() !== oldName.trim().toLowerCase() && state.prompts.includes(trimmed))
-                    return alert('That name\u2019s already taken.');
-                try{
-                    const res = await apiFetch(`/prompts/${encodeURIComponent(oldName)}/rename`, {
-                        method:'PUT',
-                        headers:{'Content-Type':'application/json'},
-                        body: JSON.stringify({new_name: trimmed})
-                    });
-                    if(!res.ok){ const j=await res.json(); throw new Error(j.detail||'Server error'); }
-                    await refreshGlobalPromptList();
-                    state.currentPrompt = trimmed;
-                    localStorage.setItem('lastGlobalPrompt', trimmed);
-                    renderPromptList();
-                    await openPromptEditor(trimmed);
-                }catch(e){ alert('Failed to rename prompt: '+e.message); }
-            });
+            await openPromptEditor(oldName);
         }
 
         function autoResize(){ userInput.style.height='auto'; userInput.style.height=Math.min(userInput.scrollHeight,200)+'px'; }


### PR DESCRIPTION
## Summary
- simplify prompt rename flow
- handle no-op prompt renames on the backend

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6847876acbd4832b9e7f49ff78e6b931