### PR TITLE
Refactor chat handlers

### DIFF
--- a/scripts/model_call.py
+++ b/scripts/model_call.py
@@ -2,9 +2,15 @@
 
 from __future__ import annotations
 
-from typing import Dict, Iterable, List
+from typing import Dict, Iterable, List, TYPE_CHECKING
 
-from . import model_launch
+import json
+from fastapi.responses import StreamingResponse
+
+from . import model_launch, model_response
+
+if TYPE_CHECKING:
+    from .MythForgeServer import ChatRequest
 
 
 def build_prompt(
@@ -60,3 +66,45 @@ def call_tagged(
     else:
         kwargs["stream"] = model_launch.MODEL_SETTINGS.get("stream", False)
     return model_launch.call_llm(prompt, **kwargs)
+
+
+def chat_stream(req: "ChatRequest"):
+    """Stream a reply from the model and store it in chat history."""
+
+    from .MythForgeServer import ensure_chat_dir, load_item, save_item
+
+    ensure_chat_dir(req.chat_id)
+    history = load_item("chat_history", req.chat_id)
+    history.append({"role": "user", "content": req.message})
+
+    chunks = call_tagged(req.global_prompt or "", req.message, stream=True)
+    parts: List[str] = []
+
+    def generate():
+        meta = {"prompt": req.global_prompt or ""}
+        yield json.dumps(meta) + "\n"
+        for text in model_response.stream_parsed(chunks):
+            parts.append(text)
+            yield text
+        assistant_reply = "".join(parts).strip()
+        history.append({"role": "assistant", "content": assistant_reply})
+        save_item("chat_history", req.chat_id, data=history)
+
+    return StreamingResponse(generate(), media_type="text/plain")
+
+
+def chat(req: "ChatRequest"):
+    """Return a standard model reply and store it in chat history."""
+
+    from .MythForgeServer import ensure_chat_dir, load_item, save_item
+
+    ensure_chat_dir(req.chat_id)
+    history = load_item("chat_history", req.chat_id)
+    history.append({"role": "user", "content": req.message})
+    output = call_tagged(req.global_prompt or "", req.message, stream=False)
+    if isinstance(output, Iterable):
+        output = next(iter(output), {})
+    assistant_reply = model_response.parse_response(output)
+    history.append({"role": "assistant", "content": assistant_reply})
+    save_item("chat_history", req.chat_id, data=history)
+    return {"detail": assistant_reply}


### PR DESCRIPTION
## Summary
- move `chat_stream` and `chat` logic to `model_call` module
- call new functions from the server endpoints

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_68478cda8ab8832b836fadb8caebd22b