### PR TITLE
Add logging for prompts and outputs

### DIFF
--- a/scripts/model_launch.py
+++ b/scripts/model_launch.py
@@ -104,7 +104,9 @@ except Exception:  # pragma: no cover
 
 
 def call_llm(prompt: str, **kwargs):
-    """Call the ``llm`` object and log all raw text outputs."""
+    """Call the ``llm`` object and log the prompt and raw output."""
+
+    myth_log("llm_prompt", prompt=prompt)
 
     if _CALL_KWARGS:
         filtered = {k: v for k, v in kwargs.items() if k in _CALL_KWARGS}
@@ -114,10 +116,12 @@ def call_llm(prompt: str, **kwargs):
     if filtered.get("stream"):
 
         def _stream():
+            parts = []
             for chunk in llm(prompt, **filtered):
                 text = chunk["choices"][0]["text"]
-                myth_log("llm_raw_output", raw=text)
+                parts.append(text)
                 yield chunk
+            myth_log("llm_raw_output", raw="".join(parts))
 
         return _stream()
 


### PR DESCRIPTION
## Summary
- log prompt text before sending to the model
- accumulate streaming output and log it once

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6847a26880cc832b8161ea1811bcea92