### PR TITLE
Update dialog focus and enter behavior

### DIFF
--- a/ui/MythForgeUI.html
+++ b/ui/MythForgeUI.html
@@ -508,6 +508,8 @@
 
         function closeSettings(){ settingsModal.style.display='none'; }
 
+       let dialogInputListener = null;
+
        function openDialog(opts){
             dialogTitle.textContent = opts.title || '';
             dialogBody.innerHTML = opts.body || '';
@@ -519,9 +521,26 @@
             dialogCancelBtn.onclick = closeDialog;
             resizeModal(dialogModal);
             dialogModal.style.display = 'flex';
+            const field = dialogBody.querySelector('input, textarea');
+            if(field){
+                field.focus();
+                if(field.select) field.select();
+                dialogInputListener = (e)=>{
+                    if(e.key==='Enter' && !e.shiftKey){
+                        e.preventDefault();
+                        dialogOkBtn.click();
+                    }
+                };
+                field.addEventListener('keydown', dialogInputListener);
+            }
         }
 
         function closeDialog(){
+            if(dialogInputListener){
+                const field = dialogBody.querySelector('input, textarea');
+                if(field) field.removeEventListener('keydown', dialogInputListener);
+                dialogInputListener = null;
+            }
             dialogModal.style.display='none';
             dialogBody.innerHTML='';
             dialogOkBtn.onclick=null;


### PR DESCRIPTION
## Summary
- auto-focus and select inputs when opening a dialog
- allow Enter to confirm dialogs

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6847a2e59900832b8d48582bfea59f12