### PR TITLE
Fix clean_text to keep spaces

### DIFF
--- a/scripts/model_call.py
+++ b/scripts/model_call.py
@@ -13,9 +13,9 @@ if TYPE_CHECKING:
 
 
 def clean_text(text: str) -> str:
-    """Return ``text`` stripped of whitespace and known tokens."""
+    """Return ``text`` with tokens removed while preserving spaces."""
 
-    cleaned = text.replace("<|eot_id|>", "").strip()
+    cleaned = text.replace("<|eot_id|>", "")
     return cleaned
 
 


### PR DESCRIPTION
## Summary
- adjust `clean_text` so it only removes model tokens and preserves spaces

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_6847a5c40d20832bbba61c8445fe7b29