### PR TITLE
Increase textarea rows in context dialog

### DIFF
--- a/ui/MythForgeUI.html
+++ b/ui/MythForgeUI.html
@@ -894,8 +894,8 @@
                 title: 'Edit Chat',
                 body:`<input id="dialog-input" type="text" style="width:100%;" value="${oldId}">`+
                      `<div id="goals-context" style="display:none;margin-top:10px;">`+
-                     `<textarea id="character-input" rows="5" placeholder="Character"></textarea>`+
-                     `<textarea id="setting-input" rows="5" placeholder="Setting" style="margin-top:10px;"></textarea>`+
+                     `<textarea id="character-input" rows="15" placeholder="Character"></textarea>`+
+                     `<textarea id="setting-input" rows="15" placeholder="Setting" style="margin-top:10px;"></textarea>`+
                      `</div>`,
                 okText:'Save',
                 extraLeft:`<button id="goals-toggle-btn">Enable Goals</button>`,


### PR DESCRIPTION
## Summary
- bump the character and setting textarea sizes to 15 rows in the chat edit dialog

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6847b1eabb60832b8bb88fd6523a6e07