### PR TITLE
Fix context popup text size

### DIFF
--- a/ui/MythForgeUI.html
+++ b/ui/MythForgeUI.html
@@ -166,6 +166,8 @@
         textarea.blocked { border: 2px solid var(--primary); }
         textarea:focus { outline: none; border-color: var(--primary); box-shadow: 0 0 0 2px var(--shadow-color); }
         .modal-content textarea { max-height: calc(90vh - 160px); padding: 12px; box-sizing: border-box; }
+        #goals-context textarea,
+        #goals-context input { font-size: 14px !important; }
         .input-area { border-top: 1px solid var(--border-color); padding: 20px; background-color: var(--bg-color); position: relative; }
         .input-container { display: flex; width: 100%; max-width: none; margin: 0; position: relative; }
         .send-button { position: absolute; right: 8px; bottom: 8px; background: none; border: none; cursor: pointer; color: var(--primary); padding: 5px; border-radius: 4px; }


### PR DESCRIPTION
## Summary
- ensure all text boxes inside context popup ignore user's text size

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_6847b210e6f8832b9ea474158b1b2608