### PR TITLE
Update goals UI logic

### DIFF
--- a/scripts/MythForgeServer.py
+++ b/scripts/MythForgeServer.py
@@ -467,10 +467,10 @@ def save_goals(chat_id: str, data: Dict[str, str]):
 
 @app.post("/chat/{chat_id}/goals/disable")
 def disable_goals(chat_id: str):
-    """Disable goals for ``chat_id`` by renaming the file."""
+    """Disable goals for ``chat_id`` by renaming the JSON file."""
 
     path = goals_path(chat_id)
-    disabled = chat_file(chat_id, "goals_disabled")
+    disabled = chat_file(chat_id, "goals_disabled.json")
     if os.path.exists(path):
         os.rename(path, disabled)
     return {"detail": "Disabled"}
@@ -478,10 +478,10 @@ def disable_goals(chat_id: str):
 
 @app.post("/chat/{chat_id}/goals/enable")
 def enable_goals(chat_id: str):
-    """Re-enable goals for ``chat_id`` if a disabled file exists."""
+    """Re-enable goals for ``chat_id`` if a disabled JSON file exists."""
 
     path = goals_path(chat_id)
-    disabled = chat_file(chat_id, "goals_disabled")
+    disabled = chat_file(chat_id, "goals_disabled.json")
     if os.path.exists(disabled):
         os.rename(disabled, path)
     return {"detail": "Enabled"}

--- a/ui/MythForgeUI.html
+++ b/ui/MythForgeUI.html
@@ -900,9 +900,9 @@
             openDialog({
                 title: 'Edit Chat',
                 body:`<input id="dialog-input" type="text" style="width:100%;" value="${oldId}">`+
-                     `<div id="goals-context" style="display:none;margin-top:10px;">`+
-                     `<textarea id="character-input" rows="15" placeholder="Character"></textarea>`+
-                     `<textarea id="setting-input" rows="15" placeholder="Setting" style="margin-top:10px;"></textarea>`+
+                     `<div id="goals-context" style="display:${goalsData.exists?'block':'none'};margin-top:10px;">`+
+                     `<textarea id="character-input" rows="15" placeholder="Character">${goalsData.character||''}</textarea>`+
+                     `<textarea id="setting-input" rows="15" placeholder="Setting" style="margin-top:10px;">${goalsData.setting||''}</textarea>`+
                      `</div>`,
                 okText:'Save',
                 extraLeft:`<button id="goals-toggle-btn">${goalsData.exists?'Disable Goals':'Enable Goals'}</button>`,


### PR DESCRIPTION
## Summary
- make disabling goals rename to `goals_disabled.json`
- when editing chats with active goals, show goals panel populated with current values

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_6847b5cbff48832ba6108b25fa72224f