### PR TITLE
Rename chat endpoint to /chat/received

### DIFF
--- a/ui/MythForgeUI.html
+++ b/ui/MythForgeUI.html
@@ -1134,7 +1134,7 @@
             updateBusyUI();
             abortController = new AbortController();
             try{
-                const response = await apiFetch('/chat/stream', {
+                const response = await apiFetch('/chat/received', {
                     method:'POST',
                     headers:{'Content-Type':'application/json'},
                     body: JSON.stringify({


### PR DESCRIPTION
## Summary
- rename `/chat/stream` route to `/chat/received`
- add `call_type` field and `import_message_data` helper
- enrich `chat_stream` to consider goals when assembling the system prompt
- update UI to post to new endpoint

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6847bcf2df5c832bae9be2c27fad4ff7