### PR TITLE
Add log before parsing model output

### DIFF
--- a/scripts/model_call.py
+++ b/scripts/model_call.py
@@ -6,6 +6,8 @@ from typing import Iterable, Iterator, List, TYPE_CHECKING, Dict
 
 import os
 
+from .server_log import myth_log
+
 import json
 from fastapi.responses import StreamingResponse
 
@@ -23,7 +25,7 @@ def clean_text(text: str, *, trim: bool = False) -> str:
 
 def parse_response(output: dict) -> str:
     """Extract and clean the text portion from a model call result."""
-
+    myth_log("pre_parse", raw=str(output))
     text = output.get("choices", [{}])[0].get("text", "")
     return clean_text(text, trim=True)
 


### PR DESCRIPTION
## Summary
- log raw model output before parsing

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6847d77eb274832bb381d8c0630783cf