### PR TITLE
Enable full GPU usage by default

### DIFF
--- a/SETTINGS.md
+++ b/SETTINGS.md
@@ -9,6 +9,8 @@ This document lists available server settings that can be changed from the **Mor
 - **Top P** – nucleus sampling cutoff.
 - **Min P** – minimum probability for nucleus sampling.
 - **Repeat Penalty** – discourages repeating text.
+- **GPU Layers** – number of layers to offload to GPU.
+  Default: `-1` for maximum utilization.
 
 ## Goals
 - **Goal Refresh Rate** – how often new goals are generated. Default: `1`.

--- a/model_settings.json
+++ b/model_settings.json
@@ -7,7 +7,7 @@
   "f16_kv": false,
   "use_mmap": true,
   "use_mlock": true,
-  "n_gpu_layers": 0,
+  "n_gpu_layers": -1,
   "main_memory_kv": true,
 
   "max_tokens": 250,

--- a/scripts/model_launch.py
+++ b/scripts/model_launch.py
@@ -85,6 +85,10 @@ for key in (
     if key in MODEL_SETTINGS and MODEL_SETTINGS[key] is not None:
         _model_config[key] = MODEL_SETTINGS[key]
 
+# Default to full GPU utilization when not specified
+if "n_gpu_layers" not in _model_config:
+    _model_config["n_gpu_layers"] = -1
+
 try:
     sig = inspect.signature(Llama)
     if "add_bos" in sig.parameters:


### PR DESCRIPTION
## Summary
- default to using all GPU layers in `model_settings.json`
- ensure `model_launch.py` falls back to full GPU utilization when not configured
- document the new `GPU Layers` option in server settings

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6847dd2334ec832ba41136ecde927ea1