### PR TITLE
Add automatic model path

### DIFF
--- a/mythforge/model.py
+++ b/mythforge/model.py
@@ -87,6 +87,9 @@ def call_llm(prompt: str, **kwargs):
 
     cmd = [LLAMA_CLI, "--prompt", prompt]
     cmd.extend(_cli_args(**kwargs))
+    if "model" not in kwargs:
+        model_path = discover_model_path()
+        cmd.extend(["--model", model_path])
 
     process = subprocess.Popen(
         cmd, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, text=True


### PR DESCRIPTION
## Summary
- set model path in `call_llm` when not provided

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6848e78a77e4832b8f4e600bd290e992