### PR TITLE
Fix temperature CLI argument mapping

### DIFF
--- a/mythforge/model.py
+++ b/mythforge/model.py
@@ -71,11 +71,15 @@ LLAMA_CLI = os.path.join("dependencies", "llama-cli.exe")
 
 
 def _cli_args(**kwargs) -> list[str]:
+    """Return CLI arguments mapping Python names to binary flags."""
+
+    option_map = {"temperature": "temp"}
     args = []
     for key, value in kwargs.items():
         if key == "stream":
             continue
-        option = f"--{key.replace('_', '-')}"
+        opt_key = option_map.get(key, key)
+        option = f"--{opt_key.replace('_', '-')}"
         if isinstance(value, bool):
             if value:
                 args.append(option)


### PR DESCRIPTION
## Summary
- map `temperature` to `temp` when calling the CLI

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_6848f002475c832bbdcb345676103d4a