### PR TITLE
Fix CLI list argument formatting

### DIFF
--- a/mythforge/model.py
+++ b/mythforge/model.py
@@ -83,6 +83,9 @@ def _cli_args(**kwargs) -> list[str]:
         if isinstance(value, bool):
             if value:
                 args.append(option)
+        elif isinstance(value, (list, tuple)):
+            for item in value:
+                args.extend([option, str(item)])
         else:
             args.extend([option, str(value)])
     return args


### PR DESCRIPTION
## Summary
- handle list-valued options like `stop` in `_cli_args`

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6848f110988c832baf59cff145b4a06d