### PR TITLE
Reload client on startup only

### DIFF
--- a/mythforge/main.py
+++ b/mythforge/main.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import json
 
 import os
+from datetime import datetime
 from typing import Dict, List
 
 from fastapi import FastAPI, HTTPException
@@ -27,6 +28,7 @@ app = FastAPI(title="Myth Forge Server")
 # --- Configuration ---------------------------------------------------------
 
 GLOBAL_PROMPTS_DIR = "global_prompts"
+SERVER_VERSION = datetime.utcnow().isoformat()
 
 
 class ChatRequest(BaseModel):
@@ -304,6 +306,12 @@ def update_settings(data: Dict[str, object]):
 @app.get("/response_prompt_status")
 def response_prompt_status():
     return {"pending": 0}
+
+
+@app.get("/server_version")
+def server_version():
+    """Return the server start time string."""
+    return {"version": SERVER_VERSION}
 
 
 # --- Standard Chat Endpoints ---------------------------------------------

--- a/ui/MythForgeUI.html
+++ b/ui/MythForgeUI.html
@@ -1248,6 +1248,22 @@
             updateBusyUI();
         }
 
+        async function checkVersionOnce(){
+            try{
+                const res = await apiFetch('/server_version');
+                if(res.ok){
+                    const data = await res.json();
+                    const saved = localStorage.getItem('serverVersion');
+                    if(saved && saved !== data.version){
+                        localStorage.setItem('serverVersion', data.version);
+                        location.reload();
+                    }else if(!saved){
+                        localStorage.setItem('serverVersion', data.version);
+                    }
+                }
+            }catch(e){ console.error('Version check failed:', e); }
+        }
+
         function setupEvents(){
             themeSelect.addEventListener('change', e=>applyTheme(e.target.value));
             textSizeSelect.addEventListener('change', e=>applyTextSize(e.target.value));
@@ -1294,6 +1310,7 @@
             await loadServerSettings();
             autoResize();
             updateBusyUI();
+            await checkVersionOnce();
         })();
     </script>
 </body>


### PR DESCRIPTION
## Summary
- only check server version once when the UI loads

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_6848f1470470832bbd90dc57a9577207