### PR TITLE
Fix server log when model missing

### DIFF
--- a/mythforge/model.py
+++ b/mythforge/model.py
@@ -95,9 +95,13 @@ def call_llm(prompt: str, **kwargs):
 
     cmd = [LLAMA_CLI, "--prompt", prompt]
     cmd.extend(_cli_args(**kwargs))
-    if "model" not in kwargs:
-        model_path = discover_model_path()
-        cmd.extend(["--model", model_path])
+    try:
+        if "model" not in kwargs:
+            model_path = discover_model_path()
+            cmd.extend(["--model", model_path])
+    except Exception as exc:
+        myth_log("call_llm_error", error=str(exc))
+        raise
 
     myth_log("call_llm_start", cmd=" ".join(cmd))
 


### PR DESCRIPTION
## Summary
- log errors thrown while building llama-cli command

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6848f901fe68832b9bcca8126aefdd25