### PR TITLE
Add streaming metadata

### DIFF
--- a/mythforge/call_core.py
+++ b/mythforge/call_core.py
@@ -323,7 +323,9 @@ def handle_chat(req: "ChatRequest", stream: bool = False):
     if stream:
 
         def _generate():
-            parts = []
+            meta = json.dumps({"prompt": prompt}, ensure_ascii=False)
+            yield meta + "\n"
+            parts: list[str] = []
             for text in processed:
                 parts.append(text)
                 yield text


### PR DESCRIPTION
## Summary
- ensure streaming API sends metadata line

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_684902974bac832bb38f929d69c4e6f7