### PR TITLE
Add stop llama CLI button

### DIFF
--- a/ui/MythForgeUI.html
+++ b/ui/MythForgeUI.html
@@ -234,6 +234,7 @@
                     <label>Goal Impulse <input id="goal-impulse-input" type="number" min="1" value="2"></label>
                     <label>New Goal Bias <input id="new-goal-bias-input" type="number" min="1" value="2"></label>
                     <button id="server-settings-save-btn">Save</button>
+                    <button id="stop-llama-btn" style="margin-top:5px;">Stop llama-cli</button>
                 </div>
                 <button id="system-toggle" class="new-chat" style="display:none;margin-top:10px;">⚙️ Last Prompt</button>
             </div>
@@ -394,6 +395,7 @@
         const goalImpulseInput  = document.getElementById('goal-impulse-input');
         const newGoalBiasInput  = document.getElementById('new-goal-bias-input');
         const serverSettingsSaveBtn = document.getElementById('server-settings-save-btn');
+        const stopLlamaBtn    = document.getElementById('stop-llama-btn');
         const promptModal      = document.getElementById('prompt-edit-modal');
         const promptModalTitle = document.getElementById('prompt-edit-title');
         const promptNameInput  = document.getElementById('prompt-name-input');
@@ -513,6 +515,18 @@
                 state.serverSettings = {...state.serverSettings, ...payload};
                 alert('Settings saved');
             }catch(e){ console.error('Failed to save server settings:', e); }
+        }
+
+        async function stopLlama(){
+            try{
+                const res = await apiFetch('/stop_llama', {method:'POST'});
+                if(!res.ok){
+                    const err = await res.json();
+                    alert('Error: ' + (err.detail || res.status));
+                    return;
+                }
+                alert('Signal sent');
+            }catch(e){ console.error('Failed to stop llama:', e); }
         }
 
         function resizeModal(modal, width){
@@ -1255,6 +1269,7 @@
             openSettingsBtn.addEventListener('click', openSettings);
             settingsSaveBtn.addEventListener('click', saveSettingsFromUI);
             serverSettingsSaveBtn.addEventListener('click', saveServerSettings);
+            stopLlamaBtn.addEventListener('click', stopLlama);
             settingsModal.addEventListener('click', e=>{ if(e.target===settingsModal) closeSettings(); });
             sendButton.addEventListener('click', () => {
                 if(userInput.value.trim()===''){


### PR DESCRIPTION
## Summary
- add `/stop_llama` endpoint for sending SIGINT to running `llama-cli.exe`
- add `Stop llama-cli` button on the Settings tab
- hook up UI logic to call the new endpoint

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68490865b580832bb385eabcb40e96ef