### PR TITLE
Disable verbose logging

### DIFF
--- a/mythforge/utils.py
+++ b/mythforge/utils.py
@@ -10,10 +10,14 @@ from typing import Any, List
 
 LOG_DIR = "server_logs"
 CHATS_DIR = "chats"
+VERBOSE_MODE = False
 
 
 def myth_log(*args, **kwargs) -> None:
-    """Log caller name with supplied arguments."""
+    """Log caller name with supplied arguments when ``VERBOSE_MODE`` is true."""
+
+    if not VERBOSE_MODE:
+        return
 
     now = datetime.utcnow()
     caller = "unknown"


### PR DESCRIPTION
## Summary
- make logging optional with a new `VERBOSE_MODE` constant

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_68490acf4480832baefca47a6af31290