### PR TITLE
Add single-turn option

### DIFF
--- a/mythforge/model.py
+++ b/mythforge/model.py
@@ -95,7 +95,7 @@ def _cli_args(**kwargs) -> list[str]:
 def call_llm(prompt: str, **kwargs):
     """Return output from :data:`LLAMA_CLI` for ``prompt`` with logging."""
 
-    cmd = [LLAMA_CLI, "--prompt", prompt]
+    cmd = [LLAMA_CLI, "--single-turn", "--prompt", prompt]
     cmd.extend(_cli_args(**kwargs))
     try:
         if "model" not in kwargs:


### PR DESCRIPTION
## Summary
- ensure single-turn mode when invoking `llama-cli`

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_684910852bc0832b820ca2b9db8dd054