### PR TITLE
Fix early stop generation issue

### DIFF
--- a/mythforge/main.py
+++ b/mythforge/main.py
@@ -524,6 +524,14 @@ def chat(req: ChatRequest):
     return handle_chat(req)
 
 
+@app.post("/abort_generation")
+def abort_generation_endpoint():
+    """Abort any in-progress model generation."""
+
+    model.abort_current_generation()
+    return {"detail": "Aborted"}
+
+
 # --- Static UI Mount ------------------------------------------------------
 
 app.mount("/", StaticFiles(directory="ui", html=True), name="static")

--- a/ui/MythForgeUI.html
+++ b/ui/MythForgeUI.html
@@ -1244,6 +1244,7 @@
 
         function stopGenerating(){
             if(abortController){ abortController.abort(); }
+            apiFetch('/abort_generation',{method:'POST'}).catch(()=>{});
             state.isGenerating=false;
             updateBusyUI();
         }


### PR DESCRIPTION
## Summary
- terminate LLM process when generation is aborted
- expose `/abort_generation` server endpoint
- ensure UI calls the abort endpoint when stopping

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_684917181614832bbea1fbf2e9d30325