### PR TITLE
Update chat endpoints to return chat_id

### DIFF
--- a/mythforge/main.py
+++ b/mythforge/main.py
@@ -320,15 +320,16 @@ def create_chat(chat_id: str):
     if os.path.exists(chat_dir):
         raise HTTPException(status_code=400, detail="Chat already exists")
     save_item("chat_history", chat_id, data=[])
-    return {"detail": f"Created chat '{chat_id}'"}
+    return {"detail": f"Created chat '{chat_id}'", "chat_id": chat_id}
 
 
 @app.get("/history/{chat_id}")
 def get_history(chat_id: str):
     try:
-        return load_item("chat_history", chat_id)
+        history = load_item("chat_history", chat_id)
     except HTTPException as exc:
         raise exc
+    return {"chat_id": chat_id, "history": history}
 
 
 @app.put("/history/{chat_id}/{index}")

--- a/ui/MythForgeUI.html
+++ b/ui/MythForgeUI.html
@@ -739,7 +739,16 @@
             try{
                 const res = await apiFetch(`/history/${encodeURIComponent(id)}`);
                 if(!res.ok) return;
-                const msgs = await res.json();
+                const data = await res.json();
+                let msgs = data;
+                if(!Array.isArray(data)){
+                    if(data.chat_id){
+                        state.currentChatId = data.chat_id;
+                        localStorage.setItem('lastChatId', data.chat_id);
+                        updateActiveChat();
+                    }
+                    msgs = data.history || [];
+                }
                 msgs.forEach(m => appendMessageToUI(m.role==='bot'?'assistant':m.role, m.content));
             }catch(e){ console.error('Failed to load history:',e); }
         }
@@ -891,6 +900,8 @@
                     alert('Error: '+(err.detail||res.status));
                     return;
                 }
+                const data = await res.json().catch(()=>({}));
+                name = data.chat_id || name;
             }catch(e){ console.error('Failed to create chat:', e); return; }
             await fetchChatList();
             state.currentChatId = name;


### PR DESCRIPTION
## Summary
- return the `chat_id` when creating a chat
- include `chat_id` in history responses
- update UI logic to handle the new API responses

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6849247d0ffc832b8f187fe3bfa8a99f