### PR TITLE
Auto-create chat when sending

### DIFF
--- a/ui/MythForgeUI.html
+++ b/ui/MythForgeUI.html
@@ -1125,7 +1125,10 @@
 
         async function sendMessage(allowEmpty=false){
             const text = userInput.value.trim();
-            if(state.isGenerating || !state.currentChatId) return;
+            if(state.isGenerating) return;
+            if(!state.currentChatId){
+                await startNewChat();
+            }
             if(text==='' && !allowEmpty) return;
             userInput.value=''; autoResize();
             sendButton.disabled=true; sendOnlyButton.disabled=true;
@@ -1224,7 +1227,10 @@
 
         async function sendMessageNoGen(){
             const text = userInput.value.trim();
-            if(text==='' || state.isGenerating || !state.currentChatId) return;
+            if(text==='' || state.isGenerating) return;
+            if(!state.currentChatId){
+                await startNewChat();
+            }
             userInput.value=''; autoResize();
             sendButton.disabled=true; sendOnlyButton.disabled=true;
             appendMessageToUI('user', text);


### PR DESCRIPTION
## Summary
- make send buttons active even with no chat
- starting a message without a chat creates one automatically

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68491e33a2e4832bb4c2289a0b2f2db2