### PR TITLE
Fix model startup paths

### DIFF
--- a/mythforge/main.py
+++ b/mythforge/main.py
@@ -10,6 +10,7 @@ from fastapi.staticfiles import StaticFiles
 from pydantic import BaseModel
 
 from .utils import (
+    ROOT_DIR,
     CHATS_DIR,
     myth_log,
     load_json,
@@ -26,7 +27,7 @@ app = FastAPI(title="Myth Forge Server")
 
 # --- Configuration ---------------------------------------------------------
 
-GLOBAL_PROMPTS_DIR = "global_prompts"
+GLOBAL_PROMPTS_DIR = os.path.join(ROOT_DIR, "global_prompts")
 
 
 class ChatRequest(BaseModel):

--- a/mythforge/model.py
+++ b/mythforge/model.py
@@ -4,15 +4,16 @@ from __future__ import annotations
 
 import json
 import os
+import platform
 import subprocess
 import threading
 from typing import Dict, Iterator
 
-from .utils import myth_log
+from .utils import ROOT_DIR, myth_log
 
 
-MODELS_DIR = "models"
-MODEL_SETTINGS_PATH = "model_settings.json"
+MODELS_DIR = os.path.join(ROOT_DIR, "models")
+MODEL_SETTINGS_PATH = os.path.join(ROOT_DIR, "model_settings.json")
 
 
 def load_model_settings(path: str = MODEL_SETTINGS_PATH) -> Dict[str, object]:
@@ -69,7 +70,12 @@ def discover_model_path() -> str:
     raise FileNotFoundError(f"No .gguf model files found under '{MODELS_DIR}'")
 
 
-LLAMA_CLI = os.path.join("dependencies", "llama-cli.exe")
+def _default_cli() -> str:
+    name = "llama-cli.exe" if platform.system() == "Windows" else "llama-cli"
+    return os.path.join(ROOT_DIR, "dependencies", name)
+
+
+LLAMA_CLI = os.path.abspath(MODEL_SETTINGS.get("llama_cli", _default_cli()))
 
 # Currently running subprocess if any
 CURRENT_PROCESS: subprocess.Popen | None = None

--- a/mythforge/utils.py
+++ b/mythforge/utils.py
@@ -8,8 +8,9 @@ import os
 from datetime import datetime
 from typing import Any, List
 
-LOG_DIR = "server_logs"
-CHATS_DIR = "chats"
+ROOT_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+LOG_DIR = os.path.join(ROOT_DIR, "server_logs")
+CHATS_DIR = os.path.join(ROOT_DIR, "chats")
 VERBOSE_MODE = False
 
 


### PR DESCRIPTION
## Summary
- make dependency and data directories relative to package root
- support custom llama-cli path via `MODEL_SETTINGS`

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684931905bf4832bb2200bf402463871