### PR TITLE
Remove abort generation feature

### DIFF
--- a/mythforge/main.py
+++ b/mythforge/main.py
@@ -526,14 +526,6 @@ def chat(req: ChatRequest):
     return handle_chat(req)
 
 
-@app.post("/abort_generation")
-def abort_generation_endpoint():
-    """Abort any in-progress model generation."""
-
-    model.abort_current_generation()
-    return {"detail": "Aborted"}
-
-
 # --- Static UI Mount ------------------------------------------------------
 
 app.mount("/", StaticFiles(directory="ui", html=True), name="static")

--- a/ui/MythForgeUI.html
+++ b/ui/MythForgeUI.html
@@ -1261,7 +1261,6 @@
 
         function stopGenerating(){
             if(abortController){ abortController.abort(); }
-            apiFetch('/abort_generation',{method:'POST'}).catch(()=>{});
             state.isGenerating=false;
             updateBusyUI();
         }


### PR DESCRIPTION
## Summary
- revert abort endpoint and process tracking logic

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68493cef8ad0832bb9081f91fabf8ed2