### PR TITLE
Refactor LLM call to use separate system prompts

### DIFF
--- a/mythforge/call_types.py
+++ b/mythforge/call_types.py
@@ -6,32 +6,37 @@ from typing import Any, Callable, Iterable, Iterator
 
 @dataclass
 class CallHandler:
-    prompt: Callable[[str, str], str]
+    """Container for prompt and response handlers."""
+
+    prompt: Callable[[str, str], tuple[str, str]]
     response: Callable[[Any], Any]
 
 
 # Prompt builders -----------------------------------------------------------
 
 
-def _fmt(system_text: str, user_text: str, call_type: str) -> str:
-    from .call_core import format_for_model
+def _fmt(system_text: str, user_text: str, call_type: str) -> tuple[str, str]:
+    """Return ``system_text`` and ``user_text`` ignoring ``call_type``."""
 
-    return format_for_model(system_text, user_text, call_type)
+    del call_type
+    return system_text, user_text
 
 
-def standard_chat_prompt(system_text: str, user_text: str) -> str:
+def standard_chat_prompt(system_text: str, user_text: str) -> tuple[str, str]:
     return _fmt(system_text, user_text, "standard_chat")
 
 
-def helper_prompt(system_text: str, user_text: str) -> str:
+def helper_prompt(system_text: str, user_text: str) -> tuple[str, str]:
     return _fmt(system_text, user_text, "helper")
 
 
-def goal_generation_prompt(system_text: str, user_text: str) -> str:
+def goal_generation_prompt(
+    system_text: str, user_text: str
+) -> tuple[str, str]:
     return _fmt(system_text, user_text, "goal_generation")
 
 
-def default_prompt(system_text: str, user_text: str) -> str:
+def default_prompt(system_text: str, user_text: str) -> tuple[str, str]:
     return _fmt(system_text, user_text, "default")
 
 

--- a/mythforge/model.py
+++ b/mythforge/model.py
@@ -98,10 +98,16 @@ def _cli_args(**kwargs) -> list[str]:
     return args
 
 
-def call_llm(prompt: str, **kwargs):
-    """Return output from :data:`LLAMA_CLI` for ``prompt`` with logging."""
+def call_llm(system_prompt: str, user_prompt: str, **kwargs):
+    """Return output from :data:`LLAMA_CLI` for the given prompts."""
 
-    cmd = [LLAMA_CLI, "--prompt", prompt]
+    cmd = [
+        LLAMA_CLI,
+        "--system-prompt",
+        system_prompt,
+        "--prompt",
+        user_prompt,
+    ]
     cmd.extend(_cli_args(**kwargs))
     if "--single-turn" not in cmd:
         cmd.insert(1, "--single-turn")


### PR DESCRIPTION
## Summary
- split prompts in `call_llm` so system prompts are passed separately
- adjust call handlers to return `(system_prompt, user_prompt)`
- update chat handling to use new prompt structure and stream metadata

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6849450a58b8832bba7fba3c9f5f6f55