### PR TITLE
Expand noise prefixes

### DIFF
--- a/mythforge/call_core.py
+++ b/mythforge/call_core.py
@@ -74,6 +74,11 @@ def _strip_model_logs(text: str) -> str:
         "llama_new_context_with_model:",
         "main:",
         "system_info:",
+        "ggml_vulkan:",
+        "load_tensors:",
+        "print_info:",
+        "llama_context:",
+        "llama_kv_cache_unified:",
     )
 
     lines = []


### PR DESCRIPTION
## Summary
- expand `_strip_model_logs` noise prefixes to cover additional log messages

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_6849469d2554832b8c0c21a979e49175