### PR TITLE
Add model warm-up on startup

### DIFF
--- a/mythforge/call_core.py
+++ b/mythforge/call_core.py
@@ -9,7 +9,13 @@ from typing import Any, Dict, Iterable, Iterator, List, TYPE_CHECKING, Callable
 
 from fastapi.responses import StreamingResponse
 
-from .model import GENERATION_CONFIG, DEFAULT_N_GPU_LAYERS, call_llm
+from .model import (
+    GENERATION_CONFIG,
+    DEFAULT_N_GPU_LAYERS,
+    call_llm,
+    warm_up,
+    _stop_warm,
+)
 from .utils import (
     CHATS_DIR,
     chat_file,
@@ -23,6 +29,10 @@ from .utils import (
 
 if TYPE_CHECKING:  # pragma: no cover - type checking only
     from .main import ChatRequest
+
+
+_current_chat_id: str | None = None
+_current_prompt: str | None = None
 
 # --- Background task queue -------------------------------------------------
 
@@ -317,6 +327,9 @@ def handle_chat(req: "ChatRequest", stream: bool = False):
 
     from .call_types import CALL_HANDLERS
 
+    global _current_chat_id, _current_prompt
+    _stop_warm()
+
     ensure_chat_dir(req.chat_id)
     history = load_json(chat_file(req.chat_id, "full.json"))
     history.append({"role": "user", "content": req.message})
@@ -342,6 +355,10 @@ def handle_chat(req: "ChatRequest", stream: bool = False):
     else:
         system_text = req.global_prompt or ""
         user_text = req.message
+
+    if req.chat_id != _current_chat_id or system_text != (_current_prompt or ""):
+        _current_chat_id = req.chat_id
+        _current_prompt = system_text
 
     system_prompt, user_prompt = handler.prompt(system_text, user_text)
     myth_log("model_input", prompt=user_prompt)
@@ -373,6 +390,7 @@ def handle_chat(req: "ChatRequest", stream: bool = False):
                 req.global_prompt or "",
             )
 
+        warm_up(_current_prompt or "")
         return StreamingResponse(_generate(), media_type="text/plain")
 
     assistant_reply = (
@@ -386,4 +404,5 @@ def handle_chat(req: "ChatRequest", stream: bool = False):
         req.chat_id,
         req.global_prompt or "",
     )
+    warm_up(_current_prompt or "")
     return {"detail": assistant_reply}

--- a/mythforge/main.py
+++ b/mythforge/main.py
@@ -25,6 +25,20 @@ from .call_core import handle_chat
 
 app = FastAPI(title="Myth Forge Server")
 
+
+@app.on_event("startup")
+def _startup() -> None:
+    """Load the model in the background."""
+
+    model.warm_up()
+
+
+@app.on_event("shutdown")
+def _shutdown() -> None:
+    """Stop any background model process."""
+
+    model._stop_warm()
+
 # --- Configuration ---------------------------------------------------------
 
 GLOBAL_PROMPTS_DIR = os.path.join(ROOT_DIR, "global_prompts")

--- a/mythforge/model.py
+++ b/mythforge/model.py
@@ -149,3 +149,60 @@ def call_llm(system_prompt: str, user_prompt: str, **kwargs):
 
 
 call_llm._patched = True
+
+# ---------------------------------------------------------------------------
+# Model warm-up utilities
+# ---------------------------------------------------------------------------
+
+_warm_process: subprocess.Popen | None = None
+
+
+def _stop_warm() -> None:
+    """Terminate the warm-up process if running."""
+
+    global _warm_process
+    if _warm_process and _warm_process.poll() is None:
+        _warm_process.terminate()
+        try:
+            _warm_process.wait(timeout=5)
+        except Exception:
+            _warm_process.kill()
+    _warm_process = None
+
+
+def warm_up(system_prompt: str = "", user_prompt: str = "") -> None:
+    """Start a background process to load the model early."""
+
+    _stop_warm()
+    cmd = [
+        LLAMA_CLI,
+        "--system-prompt",
+        system_prompt,
+        "--prompt",
+        user_prompt,
+        "--single-turn",
+        "--no-warmup",
+    ]
+    try:
+        model_path = discover_model_path()
+        cmd.extend(["--model", model_path])
+    except Exception as exc:  # pragma: no cover - best effort
+        myth_log("warm_up_error", error=str(exc))
+        return
+
+    try:
+        _warm_process = subprocess.Popen(
+            cmd, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL, text=True
+        )
+    except Exception as exc:  # pragma: no cover - best effort
+        myth_log("warm_up_error", error=str(exc))
+        _warm_process = None
+
+
+__all__ = [
+    "GENERATION_CONFIG",
+    "DEFAULT_N_GPU_LAYERS",
+    "call_llm",
+    "warm_up",
+    "_stop_warm",
+]


### PR DESCRIPTION
## Summary
- warm up the language model in a background process
- manage model warm-up during chat handling
- start and stop warm-up on app startup/shutdown

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68494e0b201c832bb29a9c39acfa79b5