### PR TITLE
Add --no-conversation flag

### DIFF
--- a/mythforge/model.py
+++ b/mythforge/model.py
@@ -108,6 +108,7 @@ def call_llm(system_prompt: str, user_prompt: str, **kwargs):
         user_prompt,
     ]
     cmd.append("--no-warmup")
+    cmd.append("--no-conversation")
     cmd.extend(_cli_args(**kwargs))
     if "--single-turn" not in cmd:
         cmd.insert(1, "--single-turn")
@@ -182,6 +183,7 @@ def warm_up(system_prompt: str = "", user_prompt: str = "") -> None:
         user_prompt,
         "--single-turn",
         "--no-warmup",
+        "--no-conversation",
     ]
     try:
         model_path = discover_model_path()
@@ -192,7 +194,10 @@ def warm_up(system_prompt: str = "", user_prompt: str = "") -> None:
 
     try:
         _warm_process = subprocess.Popen(
-            cmd, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL, text=True
+            cmd,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+            text=True,
         )
     except Exception as exc:  # pragma: no cover - best effort
         myth_log("warm_up_error", error=str(exc))


### PR DESCRIPTION
## Summary
- add `--no-conversation` to model command
- propagate flag in warm up path

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68494f173a0c832b914fabad61d83c46