### PR TITLE
Refactor call logic into templates

### DIFF
--- a/mythforge/call_templates/default.py
+++ b/mythforge/call_templates/default.py
@@ -1,0 +1,26 @@
+from __future__ import annotations
+
+from typing import Any, Iterable
+
+from ..main import ChatRequest
+
+
+def prepare(req: ChatRequest, history: list) -> tuple[str, str]:
+    """Return basic prompts when no type matches."""
+
+    del history
+    return req.global_prompt or "", req.message
+
+
+def prompt(system_text: str, user_text: str) -> tuple[str, str]:
+    """Return system and user prompt text."""
+
+    return system_text, user_text
+
+
+def response(result: Any) -> Any:
+    """Return the raw model response."""
+
+    if isinstance(result, Iterable):
+        result = next(iter(result), {})
+    return result

--- a/mythforge/call_templates/goal_generation.py
+++ b/mythforge/call_templates/goal_generation.py
@@ -1,0 +1,28 @@
+from __future__ import annotations
+
+from typing import Any, Iterable
+
+from ..main import ChatRequest
+
+
+def prepare(req: ChatRequest, history: list) -> tuple[str, str]:
+    """Return prompts for goal generation calls."""
+
+    del history
+    return req.global_prompt or "", req.message
+
+
+def prompt(system_text: str, user_text: str) -> tuple[str, str]:
+    """Return system and user prompt text."""
+
+    return system_text, user_text
+
+
+def response(result: Any) -> str:
+    """Return a single parsed model response."""
+
+    from ..call_core import parse_response
+
+    if isinstance(result, Iterable):
+        result = next(iter(result), {})
+    return parse_response(result)

--- a/mythforge/call_templates/helper.py
+++ b/mythforge/call_templates/helper.py
@@ -1,0 +1,28 @@
+from __future__ import annotations
+
+from typing import Any, Iterable
+
+from ..main import ChatRequest
+
+
+def prepare(req: ChatRequest, history: list) -> tuple[str, str]:
+    """Return prompts for helper calls."""
+
+    del history
+    return req.global_prompt or "", req.message
+
+
+def prompt(system_text: str, user_text: str) -> tuple[str, str]:
+    """Return system and user prompt text."""
+
+    return system_text, user_text
+
+
+def response(result: Any) -> str:
+    """Return a single parsed model response."""
+
+    from ..call_core import parse_response
+
+    if isinstance(result, Iterable):
+        result = next(iter(result), {})
+    return parse_response(result)

--- a/mythforge/call_templates/standard_chat.py
+++ b/mythforge/call_templates/standard_chat.py
@@ -1,0 +1,43 @@
+from __future__ import annotations
+
+import json
+from typing import Any, Dict, Iterable, Iterator, List
+
+from ..main import ChatRequest
+from ..utils import goals_exists, goals_path
+
+
+def prepare(
+    req: ChatRequest, history: List[Dict[str, Any]]
+) -> tuple[str, str]:
+    """Return prompts for a standard chat call."""
+
+    system_parts = [req.global_prompt or ""]
+    if goals_exists(req.chat_id):
+        try:
+            with open(goals_path(req.chat_id), "r", encoding="utf-8") as fh:
+                data = json.load(fh)
+            if isinstance(data, dict):
+                if data.get("character"):
+                    system_parts.append(data["character"])
+                if data.get("setting"):
+                    system_parts.append(data["setting"])
+        except Exception as exc:
+            print(f"Failed to load goals for '{req.chat_id}': {exc}")
+    system_text = "\n".join(p for p in system_parts if p)
+    user_text = "\n".join(m.get("content", "") for m in history)
+    return system_text, user_text
+
+
+def prompt(system_text: str, user_text: str) -> tuple[str, str]:
+    """Return system and user prompt text."""
+
+    return system_text, user_text
+
+
+def response(result: Iterable[dict]) -> Iterator[str]:
+    """Yield parsed output for streaming responses."""
+
+    from ..call_core import stream_parsed
+
+    return stream_parsed(result)

--- a/mythforge/call_types.py
+++ b/mythforge/call_types.py
@@ -1,78 +1,48 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Any, Callable, Iterable, Iterator
+from typing import Any, Callable, Iterable, Iterator, TYPE_CHECKING
+
+from .call_templates import (
+    standard_chat,
+    helper,
+    goal_generation,
+    default as default_call,
+)
+
+if TYPE_CHECKING:  # pragma: no cover - type checking only
+    from .main import ChatRequest
 
 
 @dataclass
 class CallHandler:
     """Container for prompt and response handlers."""
 
+    prepare: Callable[["ChatRequest", list], tuple[str, str]]
     prompt: Callable[[str, str], tuple[str, str]]
     response: Callable[[Any], Any]
 
 
-# Prompt builders -----------------------------------------------------------
-
-
-def _fmt(system_text: str, user_text: str, call_type: str) -> tuple[str, str]:
-    """Return ``system_text`` and ``user_text`` ignoring ``call_type``."""
-
-    del call_type
-    return system_text, user_text
-
-
-def standard_chat_prompt(system_text: str, user_text: str) -> tuple[str, str]:
-    return _fmt(system_text, user_text, "standard_chat")
-
-
-def helper_prompt(system_text: str, user_text: str) -> tuple[str, str]:
-    return _fmt(system_text, user_text, "helper")
-
-
-def goal_generation_prompt(
-    system_text: str, user_text: str
-) -> tuple[str, str]:
-    return _fmt(system_text, user_text, "goal_generation")
-
-
-def default_prompt(system_text: str, user_text: str) -> tuple[str, str]:
-    return _fmt(system_text, user_text, "default")
-
-
-# Response handlers --------------------------------------------------------
-
-
-def standard_chat_response(result: Iterable[dict]) -> Iterator[str]:
-    from .call_core import stream_parsed
-
-    return stream_parsed(result)
-
-
-def helper_response(result: Any) -> str:
-    from .call_core import parse_response
-
-    if isinstance(result, Iterable):
-        result = next(iter(result), {})
-    return parse_response(result)
-
-
-def goal_generation_response(result: Any) -> str:
-    from .call_core import parse_response
-
-    if isinstance(result, Iterable):
-        result = next(iter(result), {})
-    return parse_response(result)
-
-
-def default_response(result: Any) -> Any:
-    return result
-
-
 CALL_HANDLERS: dict[str, CallHandler] = {
-    "standard_chat": CallHandler(standard_chat_prompt, standard_chat_response),
-    "helper": CallHandler(helper_prompt, helper_response),
-    "goal_generation": CallHandler(goal_generation_prompt, goal_generation_response),
-    "user_message": CallHandler(standard_chat_prompt, standard_chat_response),
-    "default": CallHandler(default_prompt, default_response),
+    "standard_chat": CallHandler(
+        standard_chat.prepare,
+        standard_chat.prompt,
+        standard_chat.response,
+    ),
+    "user_message": CallHandler(
+        standard_chat.prepare,
+        standard_chat.prompt,
+        standard_chat.response,
+    ),
+    "helper": CallHandler(helper.prepare, helper.prompt, helper.response),
+    "goal_generation": CallHandler(
+        goal_generation.prepare,
+        goal_generation.prompt,
+        goal_generation.response,
+    ),
+    "default": CallHandler(
+        default_call.prepare,
+        default_call.prompt,
+        default_call.response,
+    ),
 }


### PR DESCRIPTION
## Summary
- add `call_templates` modules with per-call instructions
- refactor `call_types` to use templates
- simplify chat handling to use template `prepare` functions

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_684bc02336b0832bae6712e2d8cffc87