### PR TITLE
Fix myth_log to always record logs

### DIFF
--- a/mythforge/utils.py
+++ b/mythforge/utils.py
@@ -15,10 +15,7 @@ VERBOSE_MODE = False
 
 
 def myth_log(*args, **kwargs) -> None:
-    """Log caller name with supplied arguments when ``VERBOSE_MODE`` is true."""
-
-    if not VERBOSE_MODE:
-        return
+    """Log the caller name with the provided arguments."""
 
     now = datetime.utcnow()
     caller = "unknown"


### PR DESCRIPTION
## Summary
- update myth_log docstring to note it always logs
- remove verbose mode check

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684bc2643834832b9eb0e947037f020a