### PR TITLE
Refactor chat request handling

### DIFF
--- a/mythforge/call_templates/default.py
+++ b/mythforge/call_templates/default.py
@@ -2,14 +2,14 @@ from __future__ import annotations
 
 from typing import Any, Iterable
 
-from ..main import ChatRequest
+from ..call_core import CallData
 
 
-def prepare(req: ChatRequest, history: list) -> tuple[str, str]:
+def prepare(call: CallData, history: list) -> tuple[str, str]:
     """Return basic prompts when no type matches."""
 
     del history
-    return req.global_prompt or "", req.message
+    return call.global_prompt or "", call.message
 
 
 def prompt(system_text: str, user_text: str) -> tuple[str, str]:

--- a/mythforge/call_templates/goal_generation.py
+++ b/mythforge/call_templates/goal_generation.py
@@ -2,14 +2,14 @@ from __future__ import annotations
 
 from typing import Any, Iterable
 
-from ..main import ChatRequest
+from ..call_core import CallData
 
 
-def prepare(req: ChatRequest, history: list) -> tuple[str, str]:
+def prepare(call: CallData, history: list) -> tuple[str, str]:
     """Return prompts for goal generation calls."""
 
     del history
-    return req.global_prompt or "", req.message
+    return call.global_prompt or "", call.message
 
 
 def prompt(system_text: str, user_text: str) -> tuple[str, str]:

--- a/mythforge/call_templates/helper.py
+++ b/mythforge/call_templates/helper.py
@@ -2,14 +2,14 @@ from __future__ import annotations
 
 from typing import Any, Iterable
 
-from ..main import ChatRequest
+from ..call_core import CallData
 
 
-def prepare(req: ChatRequest, history: list) -> tuple[str, str]:
+def prepare(call: CallData, history: list) -> tuple[str, str]:
     """Return prompts for helper calls."""
 
     del history
-    return req.global_prompt or "", req.message
+    return call.global_prompt or "", call.message
 
 
 def prompt(system_text: str, user_text: str) -> tuple[str, str]:

--- a/mythforge/call_templates/standard_chat.py
+++ b/mythforge/call_templates/standard_chat.py
@@ -3,19 +3,17 @@ from __future__ import annotations
 import json
 from typing import Any, Dict, Iterable, Iterator, List
 
-from ..main import ChatRequest
+from ..call_core import CallData
 from ..utils import goals_exists, goals_path
 
 
-def prepare(
-    req: ChatRequest, history: List[Dict[str, Any]]
-) -> tuple[str, str]:
+def prepare(call: CallData, history: List[Dict[str, Any]]) -> tuple[str, str]:
     """Return prompts for a standard chat call."""
 
-    system_parts = [req.global_prompt or ""]
-    if goals_exists(req.chat_id):
+    system_parts = [call.global_prompt or ""]
+    if goals_exists(call.chat_id):
         try:
-            with open(goals_path(req.chat_id), "r", encoding="utf-8") as fh:
+            with open(goals_path(call.chat_id), "r", encoding="utf-8") as fh:
                 data = json.load(fh)
             if isinstance(data, dict):
                 if data.get("character"):
@@ -23,7 +21,7 @@ def prepare(
                 if data.get("setting"):
                     system_parts.append(data["setting"])
         except Exception as exc:
-            print(f"Failed to load goals for '{req.chat_id}': {exc}")
+            print(f"Failed to load goals for '{call.chat_id}': {exc}")
     system_text = "\n".join(p for p in system_parts if p)
     user_text = "\n".join(m.get("content", "") for m in history)
     return system_text, user_text

--- a/mythforge/call_types.py
+++ b/mythforge/call_types.py
@@ -11,14 +11,14 @@ from .call_templates import (
 )
 
 if TYPE_CHECKING:  # pragma: no cover - type checking only
-    from .main import ChatRequest
+    from .call_core import CallData
 
 
 @dataclass
 class CallHandler:
     """Container for prompt and response handlers."""
 
-    prepare: Callable[["ChatRequest", list], tuple[str, str]]
+    prepare: Callable[["CallData", list], tuple[str, str]]
     prompt: Callable[[str, str], tuple[str, str]]
     response: Callable[[Any], Any]
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,7 +1,8 @@
 import json
 
 from mythforge.utils import load_json
-from mythforge.main import ChatRequest, import_message_data
+from mythforge.main import ChatRequest
+from mythforge.call_core import build_call
 
 
 def test_load_json_basic(tmp_path):
@@ -15,13 +16,13 @@ def test_load_json_missing(tmp_path):
     assert load_json(str(path)) == []
 
 
-def test_import_message_data(tmp_path, monkeypatch):
+def test_build_call(tmp_path, monkeypatch):
     prompt_dir = tmp_path / "prompts"
     prompt_dir.mkdir()
-    monkeypatch.setattr("mythforge.main.GLOBAL_PROMPTS_DIR", str(prompt_dir))
+    monkeypatch.setattr("mythforge.utils.GLOBAL_PROMPTS_DIR", str(prompt_dir))
     data = {"name": "Example", "content": "Hello"}
     (prompt_dir / "Example.json").write_text(json.dumps(data))
-    req = ChatRequest(chat_id="1", message="hi", global_prompt="Example", call_type="")
-    updated = import_message_data(req)
-    assert updated.call_type == "user_message"
-    assert updated.global_prompt == "Hello"
+    req = ChatRequest(chat_id="1", message="hi")
+    call = build_call(req)
+    assert call.call_type == "standard_chat"
+    assert call.global_prompt == "Hello"

--- a/ui/MythForgeUI.html
+++ b/ui/MythForgeUI.html
@@ -1153,8 +1153,7 @@
                     headers:{'Content-Type':'application/json'},
                     body: JSON.stringify({
                         chat_id: state.currentChatId,
-                        message: text,
-                        global_prompt: state.currentPrompt
+                        message: text
                     }),
                     signal: abortController.signal
                 });
@@ -1249,7 +1248,7 @@
                 await apiFetch('/message', {
                     method:'POST',
                     headers:{'Content-Type':'application/json'},
-                    body: JSON.stringify({chat_id: state.currentChatId, message: text, global_prompt: state.currentPrompt})
+                    body: JSON.stringify({chat_id: state.currentChatId, message: text})
                 });
             }catch(err){
                 console.error('Send only failed:', err);


### PR DESCRIPTION
## Summary
- remove `global_prompt` and `call_type` from `ChatRequest`
- introduce `CallData` and `build_call` to collect prompt and type internally
- refactor call templates and handlers to use `CallData`
- relocate prompt helper utilities to `utils`
- adjust UI and tests for new API

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_684bc830fa60832b9fdc018390bc871b