### PR TITLE
Update global prompt handling

### DIFF
--- a/mythforge/call_core.py
+++ b/mythforge/call_core.py
@@ -59,7 +59,6 @@ def build_call(req: "ChatRequest") -> CallData:
     return CallData(
         chat_id=req.chat_id,
         message=req.message,
-        global_prompt=_default_global_prompt(),
     )
 
 

--- a/mythforge/call_templates/default.py
+++ b/mythforge/call_templates/default.py
@@ -2,14 +2,16 @@ from __future__ import annotations
 
 from typing import Any, Iterable
 
-from ..call_core import CallData
+from ..call_core import CallData, _default_global_prompt
 
 
 def prepare(call: CallData, history: list) -> tuple[str, str]:
     """Return basic prompts when no type matches."""
 
     del history
-    return call.global_prompt or "", call.message
+    if not call.global_prompt:
+        call.global_prompt = _default_global_prompt()
+    return call.global_prompt, call.message
 
 
 def prompt(system_text: str, user_text: str) -> tuple[str, str]:

--- a/mythforge/call_templates/goal_generation.py
+++ b/mythforge/call_templates/goal_generation.py
@@ -2,14 +2,16 @@ from __future__ import annotations
 
 from typing import Any, Iterable
 
-from ..call_core import CallData
+from ..call_core import CallData, _default_global_prompt
 
 
 def prepare(call: CallData, history: list) -> tuple[str, str]:
     """Return prompts for goal generation calls."""
 
     del history
-    return call.global_prompt or "", call.message
+    if not call.global_prompt:
+        call.global_prompt = _default_global_prompt()
+    return call.global_prompt, call.message
 
 
 def prompt(system_text: str, user_text: str) -> tuple[str, str]:

--- a/mythforge/call_templates/helper.py
+++ b/mythforge/call_templates/helper.py
@@ -2,14 +2,16 @@ from __future__ import annotations
 
 from typing import Any, Iterable
 
-from ..call_core import CallData
+from ..call_core import CallData, _default_global_prompt
 
 
 def prepare(call: CallData, history: list) -> tuple[str, str]:
     """Return prompts for helper calls."""
 
     del history
-    return call.global_prompt or "", call.message
+    if not call.global_prompt:
+        call.global_prompt = _default_global_prompt()
+    return call.global_prompt, call.message
 
 
 def prompt(system_text: str, user_text: str) -> tuple[str, str]:

--- a/mythforge/call_templates/standard_chat.py
+++ b/mythforge/call_templates/standard_chat.py
@@ -3,14 +3,17 @@ from __future__ import annotations
 import json
 from typing import Any, Dict, Iterable, Iterator, List
 
-from ..call_core import CallData
+from ..call_core import CallData, _default_global_prompt
 from ..utils import goals_exists, goals_path
 
 
 def prepare(call: CallData, history: List[Dict[str, Any]]) -> tuple[str, str]:
     """Return prompts for a standard chat call."""
 
-    system_parts = [call.global_prompt or ""]
+    if not call.global_prompt:
+        call.global_prompt = _default_global_prompt()
+
+    system_parts = [call.global_prompt]
     if goals_exists(call.chat_id):
         try:
             with open(goals_path(call.chat_id), "r", encoding="utf-8") as fh:

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -3,6 +3,7 @@ import json
 from mythforge.utils import load_json
 from mythforge.main import ChatRequest
 from mythforge.call_core import build_call
+from mythforge.call_templates import standard_chat
 
 
 def test_load_json_basic(tmp_path):
@@ -25,4 +26,7 @@ def test_build_call(tmp_path, monkeypatch):
     req = ChatRequest(chat_id="1", message="hi")
     call = build_call(req)
     assert call.call_type == "standard_chat"
+    assert call.global_prompt == ""
+
+    system_text, user_text = standard_chat.prepare(call, [])
     assert call.global_prompt == "Hello"


### PR DESCRIPTION
## Summary
- remove default global prompt from CallData
- set the prompt during call template preparation
- adjust tests to cover new behaviour

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_684bcf9adbfc832b93047b0698366b1f