### PR TITLE
Refactor prompt assembly for standard chat

### DIFF
--- a/mythforge/call_templates/standard_chat.py
+++ b/mythforge/call_templates/standard_chat.py
@@ -3,37 +3,56 @@ from __future__ import annotations
 import json
 from typing import Any, Dict, Iterable, Iterator, List
 
-from ..call_core import CallData, _default_global_prompt
+from ..call_core import CallData, _default_global_prompt, format_for_model
 from ..utils import goals_exists, goals_path
 
 
-def prepare(call: CallData, history: List[Dict[str, Any]]) -> tuple[str, str]:
-    """Return prompts for a standard chat call."""
+def prepare_system_text(call: CallData) -> str:
+    """Return the system prompt text for ``call``."""
 
     if not call.global_prompt:
         call.global_prompt = _default_global_prompt()
 
-    system_parts = [call.global_prompt]
+    parts = [call.global_prompt]
     if goals_exists(call.chat_id):
         try:
             with open(goals_path(call.chat_id), "r", encoding="utf-8") as fh:
                 data = json.load(fh)
             if isinstance(data, dict):
                 if data.get("character"):
-                    system_parts.append(data["character"])
+                    parts.append(data["character"])
                 if data.get("setting"):
-                    system_parts.append(data["setting"])
-        except Exception as exc:
+                    parts.append(data["setting"])
+                if data.get("in_progress"):
+                    goals = ", ".join(str(g) for g in data["in_progress"])
+                    parts.append(f"Active Goals: {goals}")
+                if data.get("completed"):
+                    goals = ", ".join(str(g) for g in data["completed"])
+                    parts.append(f"Completed Goals: {goals}")
+        except Exception as exc:  # pragma: no cover - best effort
             print(f"Failed to load goals for '{call.chat_id}': {exc}")
-    system_text = "\n".join(p for p in system_parts if p)
-    user_text = "\n".join(m.get("content", "") for m in history)
+    return "\n".join(p for p in parts if p)
+
+
+def prepare_user_text(history: List[Dict[str, Any]]) -> str:
+    """Return the user prompt text from ``history``."""
+
+    return "\n".join(m.get("content", "") for m in history)
+
+
+def prepare(call: CallData, history: List[Dict[str, Any]]) -> tuple[str, str]:
+    """Return prompts for a standard chat call."""
+
+    system_text = prepare_system_text(call)
+    user_text = prepare_user_text(history)
     return system_text, user_text
 
 
 def prompt(system_text: str, user_text: str) -> tuple[str, str]:
-    """Return system and user prompt text."""
+    """Return formatted prompts for model input."""
 
-    return system_text, user_text
+    combined = format_for_model(system_text, user_text, "standard_chat")
+    return "", combined
 
 
 def response(result: Iterable[dict]) -> Iterator[str]:


### PR DESCRIPTION
## Summary
- modularize `standard_chat` prompt assembly
- include character, setting, and goal lists in system prompt
- format final prompt for the model

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684bd29f1be4832ba93d313a133de808