### PR TITLE
Sync goals state with memory

### DIFF
--- a/mythforge/call_core.py
+++ b/mythforge/call_core.py
@@ -22,14 +22,13 @@ from .utils import (
     CHATS_DIR,
     chat_file,
     ensure_chat_dir,
-    goals_exists,
-    goals_path,
     load_json,
     myth_log,
     save_json,
     list_prompt_names,
     get_global_prompt_content,
 )
+from . import memory
 
 if TYPE_CHECKING:  # pragma: no cover - type checking only
     from .main import ChatRequest
@@ -67,9 +66,7 @@ _current_prompt: str | None = None
 
 # --- Background task queue -------------------------------------------------
 
-_task_queue: queue.Queue[tuple[str, Callable[..., None], tuple]] = (
-    queue.Queue()
-)
+_task_queue: queue.Queue[tuple[str, Callable[..., None], tuple]] = queue.Queue()
 _queued_types: set[str] = set()
 
 
@@ -291,20 +288,14 @@ def _dedupe_new_goals(
 def _maybe_generate_goals(chat_id: str, global_prompt: str) -> None:
     from .call_types import CALL_HANDLERS
 
-    if not goals_exists(chat_id):
+    goals = memory.MEMORY.goals_data
+    if not goals.enabled:
         return
-    try:
-        with open(goals_path(chat_id), "r", encoding="utf-8") as f:
-            data = json.load(f)
-        character = data.get("character", "")
-        setting = data.get("setting", "")
-    except Exception:
-        return
+    character = goals.character
+    setting = goals.setting
 
     state = _load_goal_state(chat_id)
-    state["messages_since_goal_eval"] = (
-        state.get("messages_since_goal_eval", 0) + 1
-    )
+    state["messages_since_goal_eval"] = state.get("messages_since_goal_eval", 0) + 1
 
     refresh = GENERATION_CONFIG.get("goal_refresh_rate", 1)
     if state["messages_since_goal_eval"] < refresh:
@@ -385,9 +376,7 @@ def handle_chat(call: CallData, stream: bool = False):
 
     system_text, user_text = handler.prepare(call, history)
 
-    if call.chat_id != _current_chat_id or system_text != (
-        _current_prompt or ""
-    ):
+    if call.chat_id != _current_chat_id or system_text != (_current_prompt or ""):
         _current_chat_id = call.chat_id
         _current_prompt = system_text
 
@@ -417,9 +406,7 @@ def handle_chat(call: CallData, stream: bool = False):
 
         return StreamingResponse(_generate(), media_type="text/plain")
 
-    assistant_reply = (
-        processed if isinstance(processed, str) else str(processed)
-    )
+    assistant_reply = processed if isinstance(processed, str) else str(processed)
     _finalize_chat(history, assistant_reply, call)
 
     return {"detail": assistant_reply}

--- a/mythforge/call_templates/standard_chat.py
+++ b/mythforge/call_templates/standard_chat.py
@@ -1,10 +1,9 @@
 from __future__ import annotations
 
-import json
 from typing import Any, Dict, Iterable, Iterator, List
 
 from ..call_core import CallData, _default_global_prompt, format_for_model
-from ..utils import goals_exists, goals_path
+from .. import memory
 
 
 def prepare_system_text(call: CallData) -> str:
@@ -14,23 +13,18 @@ def prepare_system_text(call: CallData) -> str:
         call.global_prompt = _default_global_prompt()
 
     parts = [call.global_prompt]
-    if goals_exists(call.chat_id):
-        try:
-            with open(goals_path(call.chat_id), "r", encoding="utf-8") as fh:
-                data = json.load(fh)
-            if isinstance(data, dict):
-                if data.get("character"):
-                    parts.append(data["character"])
-                if data.get("setting"):
-                    parts.append(data["setting"])
-                if data.get("in_progress"):
-                    goals = ", ".join(str(g) for g in data["in_progress"])
-                    parts.append(f"Active Goals: {goals}")
-                if data.get("completed"):
-                    goals = ", ".join(str(g) for g in data["completed"])
-                    parts.append(f"Completed Goals: {goals}")
-        except Exception as exc:  # pragma: no cover - best effort
-            print(f"Failed to load goals for '{call.chat_id}': {exc}")
+    goals = memory.MEMORY.goals_data
+    if goals.enabled:
+        if goals.character:
+            parts.append(goals.character)
+        if goals.setting:
+            parts.append(goals.setting)
+        if goals.active_goals:
+            joined = ", ".join(str(g) for g in goals.active_goals)
+            parts.append(f"Active Goals: {joined}")
+        if goals.deactive_goals:
+            joined = ", ".join(str(g) for g in goals.deactive_goals)
+            parts.append(f"Completed Goals: {joined}")
     return "\n".join(p for p in parts if p)
 
 


### PR DESCRIPTION
## Summary
- centralize goals tracking by adding `load_goals` in `memory`
- use in-memory goals when preparing chat prompts
- generate new goals only if memory says goals are enabled
- update endpoints to refresh memory when chats change
- ensure new chats disable goals by default

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_684bd9edf0d4832ba9acc4c7fc305031