### PR TITLE
Implement token listener for chat streaming

### DIFF
--- a/mythforge/call_core.py
+++ b/mythforge/call_core.py
@@ -408,10 +408,24 @@ def handle_chat(call: CallData, stream: bool = False):
                 ensure_ascii=False,
             )
             yield meta + "\n"
+
+            send_ui = False
             parts: list[str] = []
             for text in processed:
-                parts.append(text)
-                yield text
+                print(text, end="", flush=True)
+
+                if not send_ui and "n_keep" in text:
+                    send_ui = True
+                    continue
+
+                if send_ui and "[end of text]" in text:
+                    send_ui = False
+                    continue
+
+                if send_ui:
+                    parts.append(text)
+                    yield text
+
             assistant_reply = "".join(parts).strip()
             _finalize_chat(history, assistant_reply, call)
 


### PR DESCRIPTION
## Summary
- intercept streaming tokens in `handle_chat`
- start forwarding to UI only after encountering `n_keep`
- stop forwarding once `[end of text]` appears but continue printing to terminal

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_684bdabe069c832ba2e0edc1a70ad182