### PR TITLE
Simplify standard chat prompt assembly

### DIFF
--- a/mythforge/call_templates/standard_chat.py
+++ b/mythforge/call_templates/standard_chat.py
@@ -39,14 +39,14 @@ def prepare(call: CallData, history: List[Dict[str, Any]]) -> tuple[str, str]:
 
     system_text = prepare_system_text(call)
     user_text = prepare_user_text(history)
-    return system_text, user_text
+    combined = format_for_model(system_text, user_text, "standard_chat")
+    return "", combined
 
 
 def prompt(system_text: str, user_text: str) -> tuple[str, str]:
-    """Return formatted prompts for model input."""
+    """Return ``system_text`` and ``user_text`` unchanged."""
 
-    combined = format_for_model(system_text, user_text, "standard_chat")
-    return "", combined
+    return system_text, user_text
 
 
 def response(result: Iterable[dict]) -> Iterator[str]:


### PR DESCRIPTION
## Summary
- inline prompt formatting in `standard_chat.prepare`
- keep `prompt` as a passthrough

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_684bdecd4628832bad277c59ec9b0e22