### PR TITLE
Fix call_llm options

### DIFF
--- a/mythforge/model.py
+++ b/mythforge/model.py
@@ -111,8 +111,10 @@ def call_llm(system_prompt: str, user_prompt: str, **kwargs):
 
     cmd = [
         LLAMA_CLI,
+        "--template",
+        "",
         "--system-prompt",
-        system_prompt,
+        "",
         "--prompt",
         user_prompt,
     ]


### PR DESCRIPTION
## Summary
- pass empty template and system prompt when calling the llama cli

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_684be3ada850832b859435c4174e7c47