### PR TITLE
Use --chat-template flag

### DIFF
--- a/mythforge/model.py
+++ b/mythforge/model.py
@@ -111,7 +111,7 @@ def call_llm(system_prompt: str, user_prompt: str, **kwargs):
 
     cmd = [
         LLAMA_CLI,
-        "--template",
+        "--chat-template",
         "",
         "--system-prompt",
         "",


### PR DESCRIPTION
## Summary
- use `--chat-template` instead of the old `--template` flag when invoking the model

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_684be4b0f1dc832b8e22cb50c532f595