### PR TITLE
Use selected global prompt for chats

### DIFF
--- a/mythforge/call_templates/standard_chat.py
+++ b/mythforge/call_templates/standard_chat.py
@@ -10,7 +10,9 @@ def prepare_system_text(call: CallData) -> str:
     """Return the system prompt text for ``call``."""
 
     if not call.global_prompt:
-        call.global_prompt = _default_global_prompt()
+        call.global_prompt = (
+            memory.MEMORY.global_prompt or _default_global_prompt()
+        )
 
     parts = [call.global_prompt]
     goals = memory.MEMORY.goals_data

--- a/mythforge/main.py
+++ b/mythforge/main.py
@@ -108,7 +108,9 @@ def save_item(
             if not os.path.isdir(old_dir):
                 raise HTTPException(status_code=404, detail="Chat not found")
             if os.path.exists(new_dir):
-                raise HTTPException(status_code=400, detail="Chat name already exists")
+                raise HTTPException(
+                    status_code=400, detail="Chat name already exists"
+                )
             os.rename(old_dir, new_dir)
             return
         ensure_chat_dir(name)
@@ -130,7 +132,9 @@ def save_item(
             os.rename(old_path, new_path)
         else:
             if data is None:
-                raise HTTPException(status_code=400, detail="No prompt data provided")
+                raise HTTPException(
+                    status_code=400, detail="No prompt data provided"
+                )
             save_global_prompt({"name": name, "content": str(data)})
         prompts = load_global_prompts()
         memory.set_global_prompt(prompts[0]["content"] if prompts else "")
@@ -203,6 +207,22 @@ def rename_prompt(name: str, data: Dict[str, str]):
 def remove_prompt(name: str):
     save_item("prompts", name, delete=True)
     return {"detail": f"Deleted prompt '{name}'"}
+
+
+@app.post("/prompts/select")
+def select_prompt(data: Dict[str, str]):
+    """Set the active global prompt to ``data['name']``."""
+
+    name = data.get("name", "").strip()
+    if not name:
+        memory.set_global_prompt("")
+        return {"detail": "Cleared"}
+
+    content = get_global_prompt_content(name)
+    if content is None:
+        raise HTTPException(status_code=404, detail="Prompt not found")
+    memory.set_global_prompt(content)
+    return {"detail": f"Selected prompt '{name}'"}
 
 
 # --- Settings Endpoints ---------------------------------------------------

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -4,6 +4,7 @@ from mythforge.utils import load_json
 from mythforge.main import ChatRequest
 from mythforge.call_core import build_call
 from mythforge.call_templates import standard_chat
+from mythforge import memory
 
 
 def test_load_json_basic(tmp_path):
@@ -30,3 +31,17 @@ def test_build_call(tmp_path, monkeypatch):
 
     system_text, user_text = standard_chat.prepare(call, [])
     assert call.global_prompt == "Hello"
+
+
+def test_memory_global_prompt(tmp_path, monkeypatch):
+    prompt_dir = tmp_path / "prompts"
+    prompt_dir.mkdir()
+    monkeypatch.setattr("mythforge.utils.GLOBAL_PROMPTS_DIR", str(prompt_dir))
+    data = {"name": "Example", "content": "Hello"}
+    (prompt_dir / "Example.json").write_text(json.dumps(data))
+    memory.initialize()
+    memory.set_global_prompt("Custom")
+    req = ChatRequest(chat_id="1", message="hi")
+    call = build_call(req)
+    system_text, _ = standard_chat.prepare(call, [])
+    assert call.global_prompt == "Custom"

--- a/ui/MythForgeUI.html
+++ b/ui/MythForgeUI.html
@@ -994,10 +994,17 @@
             });
         }
 
-        function selectPrompt(name){
+        async function selectPrompt(name){
             state.currentPrompt = name;
             localStorage.setItem('lastGlobalPrompt', name);
             renderPromptList();
+            try{
+                await apiFetch('/prompts/select', {
+                    method:'POST',
+                    headers:{'Content-Type':'application/json'},
+                    body: JSON.stringify({name})
+                });
+            }catch(e){ console.error('Failed to update prompt:', e); }
         }
 
         async function deletePrompt(name){


### PR DESCRIPTION
## Summary
- make `standard_chat` read the active prompt from memory
- add endpoint to select the active global prompt
- notify the server when prompt selection changes in the UI
- test global prompt selection through memory

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684bedd1ea38832b9425b0a22456d756