### PR TITLE
Add prompt handler for standard chat

### DIFF
--- a/mythforge/call_templates/standard_chat.py
+++ b/mythforge/call_templates/standard_chat.py
@@ -45,6 +45,12 @@ def prepare(call: CallData, history: List[Dict[str, Any]]) -> tuple[str, str]:
     return "", combined
 
 
+def prompt(system_text: str, user_text: str) -> tuple[str, str]:
+    """Return ``system_text`` and ``user_text`` for the model."""
+
+    return system_text, user_text
+
+
 def response(result: Iterable[dict]) -> Iterator[str]:
     """Yield parsed output for streaming responses."""
 


### PR DESCRIPTION
## Summary
- fix missing `prompt` function in `standard_chat`

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_684bf5692ac8832b88c912657840b025