### PR TITLE
Maintain global prompt selection across reloads

### DIFF
--- a/ui/MythForgeUI.html
+++ b/ui/MythForgeUI.html
@@ -788,8 +788,11 @@
                 const json = await res.json();
                 state.prompts = json.prompts.sort((a,b)=>a.localeCompare(b));
                 const last = localStorage.getItem('lastGlobalPrompt');
-                if(last && state.prompts.includes(last)) state.currentPrompt = last;
-                renderPromptList();
+                if(last && state.prompts.includes(last)){
+                    await selectPrompt(last);
+                }else{
+                    renderPromptList();
+                }
             }catch(e){ console.error('Failed to load prompts:',e); }
         }
 


### PR DESCRIPTION
## Summary
- update `refreshGlobalPromptList` to apply saved prompt via `selectPrompt`

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_684c0197a5f8832bab312d0df8193bcf