### PR TITLE
Fix incorrect chat deletion

### DIFF
--- a/ui/MythForgeUI.html
+++ b/ui/MythForgeUI.html
@@ -711,7 +711,7 @@
                 deleteBtn.className = 'chat-action-btn';
                 deleteBtn.textContent = '✕';
                 deleteBtn.title = 'Delete chat';
-                deleteBtn.onclick = (e)=>{ e.stopPropagation(); deleteChat(); };
+                deleteBtn.onclick = (e)=>{ e.stopPropagation(); deleteChat(id); };
                 div.appendChild(deleteBtn);
 
                 div.onclick = () => loadChat(id);
@@ -932,11 +932,11 @@
             systemToggle.style.display = 'none';
         }
 
-        async function deleteChat(){
-            if(!state.currentChatId) return alert('Nothing to delete.');
+        async function deleteChat(chatId = state.currentChatId){
+            if(!chatId) return alert('Nothing to delete.');
             confirmDialog('Are you sure you want to delete this chat?', async ()=>{
                 try{
-                const res = await apiFetch(`/chats/${encodeURIComponent(state.currentChatId)}`, {method:'DELETE'});
+                const res = await apiFetch(`/chats/${encodeURIComponent(chatId)}`, {method:'DELETE'});
                 if(!res.ok){ if(res.status===404) throw new Error('Chat not found on server.'); else throw new Error('Unknown server error.'); }
                 await fetchChatList();
                 state.currentChatId = state.chats.length ? state.chats[0] : '';


### PR DESCRIPTION
meow
## Summary
- ensure chat history delete button targets the correct chat by passing the chat id
- update `deleteChat` to accept an optional `chatId` parameter

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_684c12812c28832bbc9be111ce878a7d