### PR TITLE
Fix chat route base path

### DIFF
--- a/mythforge/main.py
+++ b/mythforge/main.py
@@ -538,7 +538,7 @@ def chat_received(
     return runner.process_user_message(req.chat_id, req.message, stream=True)
 
 
-@chat_router.post("")
+@chat_router.post("/")
 def chat(
     req: ChatRequest,
     runner: ChatRunner = Depends(lambda: chat_runner),


### PR DESCRIPTION
## Summary
- ensure chat POST route uses `/` path so it registers correctly

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684c128b7624832b8ab2a77b7b1998c6