### PR TITLE
Fix non-stream chat handling

### DIFF
--- a/mythforge/call_core.py
+++ b/mythforge/call_core.py
@@ -60,9 +60,7 @@ def build_call(req: "ChatRequest") -> CallData:
 
 # --- Background task queue -------------------------------------------------
 
-_task_queue: queue.Queue[tuple[str, Callable[..., None], tuple]] = (
-    queue.Queue()
-)
+_task_queue: queue.Queue[tuple[str, Callable[..., None], tuple]] = queue.Queue()
 _queued_types: set[str] = set()
 
 
@@ -184,9 +182,7 @@ def _maybe_generate_goals(
     setting = goals.setting
 
     state = _load_goal_state(chat_id)
-    state["messages_since_goal_eval"] = (
-        state.get("messages_since_goal_eval", 0) + 1
-    )
+    state["messages_since_goal_eval"] = state.get("messages_since_goal_eval", 0) + 1
 
     refresh = GENERATION_CONFIG.get("goal_refresh_rate", 1)
     if state["messages_since_goal_eval"] < refresh:
@@ -279,9 +275,7 @@ def handle_chat(
 
     system_text, user_text = handler.prepare(call, history)
 
-    if call.chat_id != current_chat_id or system_text != (
-        current_prompt or ""
-    ):
+    if call.chat_id != current_chat_id or system_text != (current_prompt or ""):
         current_chat_id = call.chat_id
         current_prompt = system_text
 
@@ -331,9 +325,13 @@ def handle_chat(
 
         return StreamingResponse(_generate(), media_type="text/plain")
 
-    assistant_reply = (
-        processed if isinstance(processed, str) else str(processed)
-    )
+    if isinstance(processed, str):
+        assistant_reply = processed
+    else:
+        try:
+            assistant_reply = "".join(processed)
+        except TypeError:
+            assistant_reply = str(processed)
     _finalize_chat(
         assistant_reply,
         call,
@@ -358,9 +356,7 @@ class ChatRunner:
         self.current_chat_id: str | None = None
         self.current_prompt: str | None = None
 
-    def process_user_message(
-        self, chat_id: str, message: str, stream: bool = False
-    ):
+    def process_user_message(self, chat_id: str, message: str, stream: bool = False):
         call = CallData(chat_id=chat_id, message=message)
         result = handle_chat(
             call,


### PR DESCRIPTION
## Summary
- handle generator output when chat streaming is disabled

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684c13c542ec832b9f647773c8ff6bfc