### PR TITLE
Fix streaming reply for chat messages

### DIFF
--- a/mythforge/main.py
+++ b/mythforge/main.py
@@ -510,7 +510,7 @@ def send_chat_message(chat_id: str, req: ChatRequest) -> Dict[str, str]:
 
     history_service.append_message(chat_id, "user", req.message)
     call = build_call(req)
-    return handle_chat(call, history_service, memory_manager)
+    return handle_chat(call, history_service, memory_manager, stream=True)
 
 
 @chat_router.post("/{chat_id}/assistant")


### PR DESCRIPTION
## Summary
- return streaming response for chat messages

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_684c15c05d48832bbe7687377d3e5eee