### PR TITLE
Update stream output parsing

### DIFF
--- a/mythforge/call_core.py
+++ b/mythforge/call_core.py
@@ -99,17 +99,22 @@ def clean_text(text: str, *, trim: bool = False) -> str:
 
 
 def parse_response(output: Any) -> str:
-    """Return ``output`` converted to ``str`` without additional parsing."""
+    """Return ``output`` as plain text."""
 
     myth_log("pre_parse", raw=str(output))
+    if isinstance(output, dict) and "text" in output:
+        return str(output["text"])
     return str(output)
 
 
 def stream_parsed(chunks: Iterable[Any]) -> Iterator[str]:
-    """Yield raw ``str`` values from streaming model output."""
+    """Yield plain text from streaming model output."""
 
     for chunk in chunks:
-        yield str(chunk)
+        if isinstance(chunk, dict) and "text" in chunk:
+            yield str(chunk["text"])
+        else:
+            yield str(chunk)
 
 
 def format_for_model(system_text: str, user_text: str) -> str:

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -2,7 +2,7 @@ import json
 
 from mythforge.utils import load_json
 from mythforge.main import ChatRequest
-from mythforge.call_core import build_call
+from mythforge.call_core import build_call, parse_response, stream_parsed
 from mythforge.call_templates import (
     standard_chat,
     helper,
@@ -71,3 +71,12 @@ def test_other_templates_use_memory_global_prompt(tmp_path, monkeypatch):
     call = build_call(req)
     system_text, _ = goal_generation.prepare(call, [])
     assert call.global_prompt == "Stored"
+
+
+def test_parse_response_extract_text():
+    assert parse_response({"text": "hello"}) == "hello"
+
+
+def test_stream_parsed_extract_text():
+    chunks = [{"text": "a"}, {"text": "b"}]
+    assert list(stream_parsed(chunks)) == ["a", "b"]


### PR DESCRIPTION
## Summary
- strip text wrappers from streaming and non-streaming responses
- test parsing functions for plain text output

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684c1da6e7b4832bb197b137d60e7cf2