### PR TITLE
Ensure UTF-8 decoding in processes

### DIFF
--- a/RunMythForge.bat
+++ b/RunMythForge.bat
@@ -1,3 +1,5 @@
 @echo off
+chcp 65001 >nul
 cd /d "%~dp0"
+set PYTHONIOENCODING=utf-8
 py -m uvicorn mythforge.main:app --host 0.0.0.0 --port 8000 --reload

--- a/mythforge/model.py
+++ b/mythforge/model.py
@@ -148,7 +148,12 @@ def call_llm(system_prompt: str, user_prompt: str, **kwargs):
 
     try:
         process = subprocess.Popen(
-            cmd, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, text=True
+            cmd,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+            text=True,
+            encoding="utf-8",
+            errors="replace",
         )
     except Exception as exc:  # pragma: no cover - best effort
         myth_log("call_llm_error", error=str(exc))
@@ -227,6 +232,8 @@ def warm_up(
             stdout=subprocess.DEVNULL,
             stderr=subprocess.DEVNULL,
             text=True,
+            encoding="utf-8",
+            errors="replace",
         )
     except Exception as exc:  # pragma: no cover - best effort
         myth_log("warm_up_error", error=str(exc))


### PR DESCRIPTION
## Summary
- ensure console uses UTF-8 on Windows
- decode llama-cli output as UTF-8

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684c212efe4c832b9a3b2bdbf2270446