### PR TITLE
Prevent blank history entries

### DIFF
--- a/mythforge/memory.py
+++ b/mythforge/memory.py
@@ -50,6 +50,11 @@ class ChatHistoryService:
         self._save(chat_id, history)
 
     def append_message(self, chat_id: str, role: str, content: str) -> None:
+        """Add ``content`` to ``chat_id`` if not blank."""
+
+        if not content.strip():
+            return
+
         history = self.load_history(chat_id)
         history.append({"role": role, "content": content})
         self._save(chat_id, history)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -67,3 +67,12 @@ def test_parse_response_extract_text():
 def test_stream_parsed_extract_text():
     chunks = [{"text": "a"}, {"text": "b"}]
     assert list(stream_parsed(chunks)) == ["a", "b"]
+
+
+def test_append_message_skips_blank(tmp_path, monkeypatch):
+    monkeypatch.setattr("mythforge.utils.CHATS_DIR", str(tmp_path))
+    svc = memory.ChatHistoryService()
+    svc.append_message("c1", "user", "   ")
+    assert svc.load_history("c1") == []
+    svc.append_message("c1", "user", "hello")
+    assert svc.load_history("c1") == [{"role": "user", "content": "hello"}]


### PR DESCRIPTION
## Summary
- skip storing empty chat messages
- test for ignoring blank messages

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684c2f1e3c7c832bbbb54c8763e3f8c2