### PR TITLE
Add interactive-first flag

### DIFF
--- a/mythforge/call_templates/standard_chat.py
+++ b/mythforge/call_templates/standard_chat.py
@@ -61,6 +61,7 @@ def prep_standard_chat() -> None:
             "--no-warmup",
             "--no-conversation",
             "--interactive",
+            "--interactive-first",
             "--model",
             _select_model_path(False),
         ]


### PR DESCRIPTION
## Summary
- add `--interactive-first` argument when launching standard chat

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_684c429a1740832b8687dcc3cea78656