### PR TITLE
Add model launch helper

### DIFF
--- a/mythforge/call_templates/goal_generation.py
+++ b/mythforge/call_templates/goal_generation.py
@@ -5,6 +5,12 @@ from typing import Any, Iterable
 from ..call_core import CallData, _default_global_prompt
 from .. import memory
 
+# -----------------------------------
+# Model launch parameters / arguments ORERRIDE
+# -----------------------------------
+
+MODEL_LAUNCH_OVERRIDE: dict = {}
+
 
 def prepare_system_text(call: CallData) -> str:
     """Return the system prompt for ``call``."""


### PR DESCRIPTION
## Summary
- centralize common model startup options in new `model_launch` function
- use overrides in `standard_chat` and `goal_generation` to customize launch
- update standard chat to call `model_launch`

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_684ca252d9d4832ba6eb52230c200d07