### PR TITLE
Centralize model launch arguments

### DIFF
--- a/mythforge/call_templates/goal_generation.py
+++ b/mythforge/call_templates/goal_generation.py
@@ -1,24 +1,16 @@
 from __future__ import annotations
 
-from typing import Any, Iterable
+from typing import Any, Iterable, Dict
 
 from ..call_core import CallData, _default_global_prompt
 from .. import memory
-from typing import Any, Dict
-from ..model import llm_args
-
-
 
 # -----------------------------------
 # Model launch parameters / arguments ORERRIDE
 # -----------------------------------
 
 MODEL_LAUNCH_OVERRIDE: Dict[str, Any] = {
-
     "n_gpu_layers": 0,
-
-    **llm_args(stream=False)
-
 }
 
 

--- a/mythforge/call_templates/standard_chat.py
+++ b/mythforge/call_templates/standard_chat.py
@@ -9,7 +9,7 @@ from typing import Any, Dict, Iterable, Iterator, List
 
 from typing import TYPE_CHECKING
 
-from ..model import model_launch, llm_args
+from ..model import model_launch
 from .. import memory
 
 if TYPE_CHECKING:  # pragma: no cover - type checking only
@@ -26,12 +26,9 @@ _TIMEOUT = 20 * 60  # 20 minutes
 # -----------------------------------
 
 MODEL_LAUNCH_OVERRIDE: Dict[str, Any] = {
-
     "interactive": True,
     "interactive_first": True,
-
-    **llm_args(stream=True),
-
+    "single_turn": False,
 }
 
 

--- a/mythforge/model.py
+++ b/mythforge/model.py
@@ -50,11 +50,12 @@ GENERATION_CONFIG = {
 
 
 def llm_args(*, stream: bool = False, background: bool = False) -> dict[str, object]:
-    """Return argument mapping for :func:`call_llm`."""
+    """Return argument overrides for :func:`call_llm`."""
 
-    args = GENERATION_CONFIG.copy()
-    args["stream"] = stream
-    args["n_gpu_layers"] = 0 if background else DEFAULT_N_GPU_LAYERS
+    args = {"stream": stream}
+    if background:
+        args["background"] = True
+        args["n_gpu_layers"] = 0
     return args
 
 
@@ -126,6 +127,9 @@ MODEL_LAUNCH_ARGS: dict[str, object] = {
     "chat_template": "",
     "no_warmup": True,
     "no_conversation": True,
+    "single_turn": True,
+    "n_gpu_layers": DEFAULT_N_GPU_LAYERS,
+    **GENERATION_CONFIG,
 }
 
 
@@ -151,8 +155,6 @@ def call_llm(system_prompt: str, user_prompt: str, **kwargs):
     kwargs.pop("background", None)
 
     cmd = model_launch(user_prompt, background=background, **kwargs)
-    if "--single-turn" not in cmd:
-        cmd.insert(1, "--single-turn")
     myth_log("call_llm_start", cmd=" ".join(cmd))
 
     try:


### PR DESCRIPTION
## Summary
- consolidate launch options in `MODEL_LAUNCH_ARGS`
- simplify `llm_args`
- update overrides for standard chat and goal generation

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_684cad98987c832babef27bad18eec1d