### PR TITLE
Remove llm_args and streamline prepare

### DIFF
--- a/mythforge/call_core.py
+++ b/mythforge/call_core.py
@@ -14,9 +14,8 @@ from .model import (
     GENERATION_CONFIG,
     DEFAULT_N_GPU_LAYERS,
     call_llm,
-    llm_args,
 )
-from .call_templates import standard_chat
+from .call_templates import standard_chat, goal_generation
 from .utils import (
     CHATS_DIR,
     chat_file,
@@ -216,7 +215,7 @@ def _maybe_generate_goals(
     raw = call_llm(
         system_prompt,
         user_prompt,
-        **llm_args(background=True),
+        **goal_generation.MODEL_LAUNCH_OVERRIDE,
     )
     text = handler.response(raw)
 
@@ -272,11 +271,9 @@ def handle_chat(
 
     from .call_types import CALL_HANDLERS
 
-    history = history_service.load_history(call.chat_id)
-
     handler = CALL_HANDLERS.get(call.call_type, CALL_HANDLERS["standard_chat"])
 
-    system_text, user_text = handler.prepare(call, history)
+    system_text, user_text = handler.prepare(call)
 
     if call.chat_id != current_chat_id or system_text != (
         current_prompt or ""
@@ -296,7 +293,7 @@ def handle_chat(
         raw = call_llm(
             system_prompt,
             user_prompt,
-            **llm_args(stream=stream),
+            stream=stream,
         )
     processed = handler.response(raw)
 

--- a/mythforge/call_templates/goal_generation.py
+++ b/mythforge/call_templates/goal_generation.py
@@ -11,15 +11,17 @@ from .. import memory
 
 MODEL_LAUNCH_OVERRIDE: Dict[str, Any] = {
     "n_gpu_layers": 0,
+    "background": True,
 }
-
 
 
 def prepare_system_text(call: CallData) -> str:
     """Return the system prompt for ``call``."""
 
     if not call.global_prompt:
-        call.global_prompt = memory.MEMORY.global_prompt or _default_global_prompt()
+        call.global_prompt = (
+            memory.MEMORY.global_prompt or _default_global_prompt()
+        )
     return call.global_prompt
 
 
@@ -29,10 +31,8 @@ def prepare_user_text(call: CallData) -> str:
     return call.message
 
 
-def prepare(call: CallData, history: list) -> tuple[str, str]:
+def prepare(call: CallData) -> tuple[str, str]:
     """Return prompts for goal generation calls."""
-
-    del history
     system_text = prepare_system_text(call)
     user_text = prepare_user_text(call)
     return system_text, user_text

--- a/mythforge/call_types.py
+++ b/mythforge/call_types.py
@@ -13,7 +13,7 @@ if TYPE_CHECKING:  # pragma: no cover - type checking only
 class CallHandler:
     """Container for prompt and response handlers."""
 
-    prepare: Callable[["CallData", list], tuple[str, str]]
+    prepare: Callable[["CallData"], tuple[str, str]]
     prompt: Callable[[str, str], tuple[str, str]]
     response: Callable[[Any], Any]
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -29,7 +29,7 @@ def test_build_call(tmp_path, monkeypatch):
     assert call.call_type == "standard_chat"
     assert call.global_prompt == ""
 
-    system_text, user_text = standard_chat.prepare(call, [])
+    system_text, user_text = standard_chat.prepare(call)
     assert call.global_prompt == "Hello"
 
 
@@ -43,7 +43,7 @@ def test_memory_global_prompt(tmp_path, monkeypatch):
     memory.set_global_prompt("Custom")
     req = ChatRequest(chat_id="1", message="hi")
     call = build_call(req)
-    system_text, _ = standard_chat.prepare(call, [])
+    system_text, _ = standard_chat.prepare(call)
     assert call.global_prompt == "Custom"
 
 
@@ -56,7 +56,7 @@ def test_goal_generation_uses_memory_global_prompt(tmp_path, monkeypatch):
 
     req = ChatRequest(chat_id="1", message="hi")
     call = build_call(req)
-    system_text, _ = goal_generation.prepare(call, [])
+    system_text, _ = goal_generation.prepare(call)
     assert call.global_prompt == "Stored"
 
 


### PR DESCRIPTION
## Summary
- centralize subprocess launch parameters in `MODEL_LAUNCH_PARAMS`
- drop `llm_args` helper
- load chat history in `standard_chat.prepare`
- move goal generation overrides to dictionary
- update tests for new `prepare` signature

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_684cb305caa4832bb5dd40d5903d8857