### PR TITLE
Fix circular import in chat handling

### DIFF
--- a/mythforge/call_core.py
+++ b/mythforge/call_core.py
@@ -15,7 +15,6 @@ from .model import (
     DEFAULT_N_GPU_LAYERS,
     call_llm,
 )
-from .call_templates import standard_chat, goal_generation
 from .utils import (
     CHATS_DIR,
     chat_file,
@@ -209,6 +208,7 @@ def _maybe_generate_goals(
     system_text = "\n".join(system_parts)
 
     from .call_types import CALL_HANDLERS
+    from .call_templates import goal_generation
 
     handler = CALL_HANDLERS["goal_generation"]
     system_prompt, user_prompt = handler.prompt(system_text, user_text)
@@ -284,6 +284,8 @@ def handle_chat(
     system_prompt, user_prompt = handler.prompt(system_text, user_text)
     myth_log("model_input", prompt=user_prompt)
     if call.call_type == "standard_chat":
+        from .call_templates import standard_chat
+
         raw = standard_chat.send_prompt(
             system_prompt,
             user_prompt,


### PR DESCRIPTION
## Summary
- defer imports of call templates inside functions
- remove top-level imports that caused cycle

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_684cb7469868832b8d6070086c7e34fa