### PR TITLE
Add CLI command mode to chat

### DIFF
--- a/mythforge/call_templates/standard_chat.py
+++ b/mythforge/call_templates/standard_chat.py
@@ -83,9 +83,33 @@ def send_prompt(system_text: str, user_text: str, *, stream: bool = False):
     from ..call_core import format_for_model
 
     with _lock:
-        _chat_process.stdin.write(
-            format_for_model(system_text, user_text) + "\n"
-        )
+        _chat_process.stdin.write(format_for_model(system_text, user_text) + "\n")
+        _chat_process.stdin.flush()
+        global _last_used
+        _last_used = time.time()
+
+    if stream:
+
+        def _stream() -> Iterator[dict[str, str]]:
+            for line in _chat_process.stdout:
+                yield {"text": line.rstrip()}
+
+        return _stream()
+
+    line = _chat_process.stdout.readline()
+    return {"text": line.rstrip()}
+
+
+def send_cli_command(command: str, *, stream: bool = False):
+    """Send ``command`` directly to the interactive CLI process."""
+
+    prep_standard_chat()
+    assert _chat_process is not None
+    assert _chat_process.stdin is not None
+    assert _chat_process.stdout is not None
+
+    with _lock:
+        _chat_process.stdin.write(command + "\n")
         _chat_process.stdin.flush()
         global _last_used
         _last_used = time.time()
@@ -108,9 +132,7 @@ def prepare_system_text(call: CallData) -> str:
     if not call.global_prompt:
         from ..call_core import _default_global_prompt
 
-        call.global_prompt = (
-            memory.MEMORY.global_prompt or _default_global_prompt()
-        )
+        call.global_prompt = memory.MEMORY.global_prompt or _default_global_prompt()
 
     parts = [call.global_prompt]
     goals = memory.MEMORY.goals_data

--- a/ui/MythForgeUI.html
+++ b/ui/MythForgeUI.html
@@ -1168,6 +1168,32 @@
                 await startNewChat();
             }
             if(text==='' && !allowEmpty) return;
+            if(text.startsWith('/')){
+                userInput.value='';
+                autoResize();
+                sendButton.disabled=true;
+                sendOnlyButton.disabled=true;
+                appendMessageToUI('user', text);
+                state.isProcessing=true;
+                updateBusyUI();
+                try{
+                    const res = await apiFetch(`/chats/${encodeURIComponent(state.currentChatId)}/cli`, {
+                        method:'POST',
+                        headers:{'Content-Type':'application/json'},
+                        body: JSON.stringify({chat_id: state.currentChatId, message: text})
+                    });
+                    const data = await res.json();
+                    appendMessageToUI('assistant', data.detail || '');
+                }catch(err){
+                    console.error('CLI command failed:', err);
+                    appendMessageToUI('assistant','[CLI error]');
+                }finally{
+                    state.isProcessing=false;
+                    updateBusyUI();
+                    userInput.focus();
+                }
+                return;
+            }
             userInput.value=''; autoResize();
             sendButton.disabled=true; sendOnlyButton.disabled=true;
             if(text!=='') appendMessageToUI('user', text);


### PR DESCRIPTION
## Summary
- send raw commands to the running llama cli
- expose new `/chats/{id}/cli` endpoint
- allow UI messages starting with `/` to be sent directly to the cli

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_684cbc40b788832b80739c8327aae618