### PR TITLE
Add running check for llama process

### DIFF
--- a/mythforge/call_templates/standard_chat.py
+++ b/mythforge/call_templates/standard_chat.py
@@ -21,12 +21,20 @@ _last_used: float = 0.0
 _lock = threading.Lock()
 _TIMEOUT = 20 * 60  # 20 minutes
 
+
+def chat_running() -> bool:
+    """Return ``True`` if the chat model subprocess is active."""
+
+    with _lock:
+        return _chat_process is not None and _chat_process.poll() is None
+
+
 # -----------------------------------
 # Model launch parameters / arguments ORERRIDE
 # -----------------------------------
 
 MODEL_LAUNCH_OVERRIDE: Dict[str, Any] = {
-    "stream": True, # this is just a placeholder. default is also true
+    "stream": True,  # this is just a placeholder. default is also true
 }
 
 

--- a/mythforge/main.py
+++ b/mythforge/main.py
@@ -35,6 +35,7 @@ from .memory import (
     initialize as init_memory,
 )
 from .call_core import ChatRunner, build_call, handle_chat
+from .call_templates import standard_chat
 
 app = FastAPI(title="Myth Forge Server")
 
@@ -163,9 +164,7 @@ def save_item(
             if not os.path.isdir(old_dir):
                 raise HTTPException(status_code=404, detail="Chat not found")
             if os.path.exists(new_dir):
-                raise HTTPException(
-                    status_code=400, detail="Chat name already exists"
-                )
+                raise HTTPException(status_code=400, detail="Chat name already exists")
             os.rename(old_dir, new_dir)
             return
         ensure_chat_dir(name)
@@ -187,12 +186,8 @@ def save_item(
             os.rename(old_path, new_path)
         else:
             if data is None:
-                raise HTTPException(
-                    status_code=400, detail="No prompt data provided"
-                )
-                raise HTTPException(
-                    status_code=400, detail="No prompt data provided"
-                )
+                raise HTTPException(status_code=400, detail="No prompt data provided")
+                raise HTTPException(status_code=400, detail="No prompt data provided")
             save_global_prompt({"name": name, "content": str(data)})
         prompts = load_global_prompts()
         memory_manager.global_prompt = prompts[0]["content"] if prompts else ""
@@ -543,6 +538,9 @@ def save_message(
 @chat_router.post("/{chat_id}/message")
 def send_chat_message(chat_id: str, req: ChatRequest) -> Dict[str, str]:
     """Generate a reply for ``req.message`` in ``chat_id``."""
+
+    if not standard_chat.chat_running():
+        raise HTTPException(status_code=503, detail="Model not running")
 
     history_service.append_message(chat_id, "user", req.message)
     call = build_call(req)


### PR DESCRIPTION
## Summary
- expose a helper to detect if the chat model process is active
- require the model to be running before accepting `/chats/{id}/message` requests

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_684cd09cb7a4832b8f569cb078d812c6