### PR TITLE
Add myth_log to standard chat launch

### DIFF
--- a/mythforge/call_templates/standard_chat.py
+++ b/mythforge/call_templates/standard_chat.py
@@ -11,6 +11,7 @@ from typing import TYPE_CHECKING
 
 from ..model import model_launch, MODEL_LAUNCH_PARAMS
 from .. import memory
+from ..utils import myth_log
 
 if TYPE_CHECKING:  # pragma: no cover - type checking only
     from ..call_core import CallData
@@ -71,6 +72,7 @@ def prep_standard_chat() -> None:
             return
 
         args = model_launch(**MODEL_LAUNCH_OVERRIDE)
+        myth_log(" ".join(args))
         popen_args = MODEL_LAUNCH_PARAMS.copy()
         popen_args["stdin"] = subprocess.PIPE
         popen_args["stdout"] = subprocess.PIPE
@@ -89,7 +91,9 @@ def send_prompt(system_text: str, user_text: str, *, stream: bool = False):
     from ..call_core import format_for_model
 
     with _lock:
-        _chat_process.stdin.write(format_for_model(system_text, user_text) + "\n")
+        _chat_process.stdin.write(
+            format_for_model(system_text, user_text) + "\n"
+        )
         _chat_process.stdin.flush()
         global _last_used
         _last_used = time.time()
@@ -138,7 +142,9 @@ def prepare_system_text(call: CallData) -> str:
     if not call.global_prompt:
         from ..call_core import _default_global_prompt
 
-        call.global_prompt = memory.MEMORY.global_prompt or _default_global_prompt()
+        call.global_prompt = (
+            memory.MEMORY.global_prompt or _default_global_prompt()
+        )
 
     parts = [call.global_prompt]
     goals = memory.MEMORY.goals_data


### PR DESCRIPTION
## Summary
- log the full launch command when starting the standard chat model

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_684cd38c77f4832ba2f6c867ade56cf4