### PR TITLE
Fix 503 when sending first chat message

### DIFF
--- a/mythforge/main.py
+++ b/mythforge/main.py
@@ -502,7 +502,7 @@ def send_chat_message(chat_id: str, req: ChatRequest) -> Dict[str, str]:
     """Generate a reply for ``req.message`` in ``chat_id``."""
 
     if not standard_chat.chat_running():
-        raise HTTPException(status_code=503, detail="Model not running")
+        standard_chat.prep_standard_chat()
 
     history_service.append_message(chat_id, "user", req.message)
     call = build_call(req)


### PR DESCRIPTION
## Summary
- automatically start the model when handling chat messages

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684ce4438370832ba634dee4b0c12f67