### PR TITLE
Adjust standard chat process

### DIFF
--- a/mythforge/call_templates/standard_chat.py
+++ b/mythforge/call_templates/standard_chat.py
@@ -73,10 +73,7 @@ def prep_standard_chat() -> None:
 
         args = model_launch(**MODEL_LAUNCH_OVERRIDE)
         myth_log(" ".join(args))
-        popen_args = MODEL_LAUNCH_PARAMS.copy()
-        popen_args["stdin"] = subprocess.PIPE
-        popen_args["stdout"] = subprocess.PIPE
-        _chat_process = subprocess.Popen(args, **popen_args)
+        _chat_process = subprocess.Popen(args, **MODEL_LAUNCH_PARAMS)
         _last_used = time.time()
         threading.Thread(target=_watchdog, daemon=True).start()
 
@@ -88,12 +85,9 @@ def send_prompt(system_text: str, user_text: str, *, stream: bool = False):
     assert _chat_process is not None
     assert _chat_process.stdin is not None
     assert _chat_process.stdout is not None
-    from ..call_core import format_for_model
 
     with _lock:
-        _chat_process.stdin.write(
-            format_for_model(system_text, user_text) + "\n"
-        )
+        _chat_process.stdin.write(system_text + user_text + "\n")
         _chat_process.stdin.flush()
         global _last_used
         _last_used = time.time()

--- a/mythforge/model.py
+++ b/mythforge/model.py
@@ -119,8 +119,7 @@ MODEL_LAUNCH_ARGS: dict[str, object] = {
     "background": False,
     "stream": True,
     **GENERATION_CONFIG,
-
-# testing currently
+    # testing currently
     "interactive_first": True,
     "no_warmup": True,
     "no_conversation": True,
@@ -131,6 +130,7 @@ MODEL_LAUNCH_ARGS: dict[str, object] = {
 # ``subprocess.Popen`` parameters for launching the model process
 MODEL_LAUNCH_PARAMS: dict[str, object] = {
     "stdout": subprocess.PIPE,
+    "stdin": subprocess.PIPE,
     "stderr": subprocess.STDOUT,
     "text": True,
     "encoding": "utf-8",


### PR DESCRIPTION
## Summary
- rely entirely on `MODEL_LAUNCH_PARAMS` for standard chat startup
- send prompts directly without additional formatting
- add `stdin` pipe to model launch parameters

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_684cefb92818832b8c4b17947f77ec6e