### PR TITLE
Fix vendor prefixed appearance

### DIFF
--- a/ui/MythForgeUI.html
+++ b/ui/MythForgeUI.html
@@ -195,8 +195,15 @@
         .sidebar-section label { display:flex; flex-direction:column; font-size:14px; }
         .sidebar-section input { background-color: var(--sidebar-btn-bg); color: var(--sidebar-text); border: 1px solid rgba(255,255,255,0.2); border-radius:4px; padding:6px 8px; margin-top:4px; font-size:14px; }
         .sidebar-section input[type=number]::-webkit-inner-spin-button,
-        .sidebar-section input[type=number]::-webkit-outer-spin-button { -webkit-appearance: none; margin: 0; }
-        .sidebar-section input[type=number] { -moz-appearance: textfield; }
+        .sidebar-section input[type=number]::-webkit-outer-spin-button {
+            appearance: none;
+            -webkit-appearance: none;
+            margin: 0;
+        }
+        .sidebar-section input[type=number] {
+            appearance: textfield;
+            -moz-appearance: textfield;
+        }
         .sidebar-section h3 { margin: 0 0 5px 0; font-size: 16px; }
     </style>
 </head>


### PR DESCRIPTION
## Summary
- ensure numeric input spin button CSS uses `appearance` before prefixed versions

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_684cf21558ac832b98e68552b5a1fad2