### PR TITLE
Prefix CLI prompt argument

### DIFF
--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -75,6 +75,17 @@ def test_stream_parsed_extract_text():
     assert list(stream_parsed(chunks)) == ["a", "b"]
 
 
+def test_format_for_model_single_line():
+    from mythforge.call_core import format_for_model
+
+    result = format_for_model("sys", "user")
+    assert "\n" not in result
+    assert result == (
+        '--prompt "<|im_start|>sys<|im_end|><|im_start|>user user<|im_end|>'
+        '<|im_start|>assistant"'
+    )
+
+
 def test_append_message_skips_blank(tmp_path, monkeypatch):
     monkeypatch.setattr("mythforge.utils.CHATS_DIR", str(tmp_path))
     svc = memory.ChatHistoryService()


### PR DESCRIPTION
## Summary
- prepend `--prompt` to formatted prompt
- escape newlines in user and system messages
- update unit test for updated formatting

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_684d14e923f4832bb58080408fc82075