### PR TITLE
Restore streaming output

### DIFF
--- a/mythforge/call_templates/standard_chat.py
+++ b/mythforge/call_templates/standard_chat.py
@@ -96,7 +96,7 @@ def send_prompt(system_text: str, user_text: str, *, stream: bool = False):
 
         def _stream() -> Iterator[dict[str, str]]:
             for line in _chat_process.stdout:
-                print(line.rstrip())
+                yield {"text": line.rstrip()}
 
         return _stream()
 
@@ -122,7 +122,7 @@ def send_cli_command(command: str, *, stream: bool = False):
 
         def _stream() -> Iterator[dict[str, str]]:
             for line in _chat_process.stdout:
-                print(line.rstrip())
+                yield {"text": line.rstrip()}
 
         return _stream()
 

--- a/mythforge/model.py
+++ b/mythforge/model.py
@@ -182,7 +182,7 @@ def call_llm(system_prompt: str, user_prompt: str, **overrides):
         def _stream() -> Iterator[dict[str, str]]:
             assert process.stdout is not None
             for line in process.stdout:
-                print(line.rstrip())
+                yield {"text": line.rstrip()}
             myth_log("call_llm_exit", code=process.wait())
 
         return _stream()


### PR DESCRIPTION
## Summary
- restore yielding dictionaries from streaming listeners

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_684d1a066ee0832b8ec9afac9c61e03e