### PR TITLE
Print streamed chat output

### DIFF
--- a/mythforge/call_templates/standard_chat.py
+++ b/mythforge/call_templates/standard_chat.py
@@ -103,6 +103,7 @@ def send_prompt(system_text: str, user_text: str, *, stream: bool = False):
 
         def _stream() -> Iterator[dict[str, str]]:
             for line in _chat_process.stdout:
+                print(line, end="", flush=True)
                 yield {"text": line.rstrip()}
 
         return _stream()


### PR DESCRIPTION
## Summary
- update `send_prompt` to print streamed data to the console

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_684d21b6c420832bbe1e54cb8cdc0a52