### PR TITLE
Add raw prompt logging

### DIFF
--- a/mythforge/call_templates/logic_check.py
+++ b/mythforge/call_templates/logic_check.py
@@ -24,6 +24,7 @@ def send_prompt(system_text: str, user_text: str) -> dict[str, str]:
         n_ctx=MODEL_LAUNCH_OVERRIDE["n_ctx"],
     )
     prompt = format_for_model(system_text, user_text)
+    myth_log("cli_input", text=prompt)
     result = llm(prompt, max_tokens=MODEL_LAUNCH_OVERRIDE["max_tokens"])
     text = ""
     if isinstance(result, dict):

--- a/mythforge/call_templates/standard_chat.py
+++ b/mythforge/call_templates/standard_chat.py
@@ -96,7 +96,9 @@ def send_prompt(system_text: str, user_text: str, *, stream: bool = False):
     assert _chat_process.stdin is not None
     assert _chat_process.stdout is not None
 
-    _chat_process.stdin.write(system_text + user_text + "\n")
+    prompt_text = system_text + user_text
+    myth_log("cli_input", text=prompt_text)
+    _chat_process.stdin.write(prompt_text + "\n")
     _chat_process.stdin.flush()
 
     if stream:

--- a/mythforge/model.py
+++ b/mythforge/model.py
@@ -170,6 +170,7 @@ def call_llm(system_prompt: str, user_prompt: str, **overrides):
 
     cmd = model_launch(user_prompt, background=background, **params)
     myth_log("call_llm_start", cmd=" ".join(cmd))
+    myth_log("cli_input", text=user_prompt)
 
     try:
         process = subprocess.Popen(cmd, **MODEL_LAUNCH_PARAMS)


### PR DESCRIPTION
## Summary
- log prompt text passed to the model in `standard_chat.send_prompt`
- log prompt text passed to the model in `logic_check.send_prompt`
- log prompt text passed to the model in `model.call_llm`

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_684d213e018c832bbd64cd8dce6dc0df