### PR TITLE
Refine server logging

### DIFF
--- a/mythforge/call_templates/logic_check.py
+++ b/mythforge/call_templates/logic_check.py
@@ -6,6 +6,7 @@ from typing import Any, Dict
 
 from ..model import _select_model_path
 from ..call_core import format_for_model, parse_response
+from ..utils import log_server_call
 
 MODEL_LAUNCH_OVERRIDE: Dict[str, Any] = {
     "background": True,
@@ -19,11 +20,14 @@ def send_prompt(system_text: str, user_text: str) -> dict[str, str]:
     """Return raw model output for ``system_text`` and ``user_text``."""
     from llama_cpp import Llama
 
+    prompt = format_for_model(system_text, user_text)
+    log_server_call(prompt)
+
     llm = Llama(
         model_path=_select_model_path(background=True),
         n_ctx=MODEL_LAUNCH_OVERRIDE["n_ctx"],
     )
-    prompt = format_for_model(system_text, user_text)
+
     result = llm(prompt, max_tokens=MODEL_LAUNCH_OVERRIDE["max_tokens"])
     text = ""
     if isinstance(result, dict):

--- a/mythforge/model.py
+++ b/mythforge/model.py
@@ -8,7 +8,7 @@ import platform
 import subprocess
 from typing import Dict, Iterator
 
-from .utils import ROOT_DIR
+from .utils import ROOT_DIR, log_server_call
 
 
 MODELS_DIR = os.path.join(ROOT_DIR, "models")
@@ -142,9 +142,7 @@ MODEL_LAUNCH_PARAMS: dict[str, object] = {
 }
 
 
-def model_launch(
-    prompt: str = "", background: bool = False, **overrides
-) -> list[str]:
+def model_launch(prompt: str = "", background: bool = False, **overrides) -> list[str]:
     """Return a command list for launching the model."""
 
     params = MODEL_LAUNCH_ARGS.copy()
@@ -161,6 +159,8 @@ def model_launch(
 
 def call_llm(system_prompt: str, user_prompt: str, **overrides):
     """Return output from :data:`LLAMA_CLI` for the given prompts."""
+
+    log_server_call(user_prompt)
 
     params = MODEL_LAUNCH_ARGS.copy()
     params.update(overrides)

--- a/mythforge/utils.py
+++ b/mythforge/utils.py
@@ -9,6 +9,8 @@ from typing import Any, List
 ROOT_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
 CHATS_DIR = os.path.join(ROOT_DIR, "chats")
 GLOBAL_PROMPTS_DIR = os.path.join(ROOT_DIR, "global_prompts")
+SERVER_LOGS_DIR = os.path.join(ROOT_DIR, "server_logs")
+MODEL_CALLS_PATH = os.path.join(SERVER_LOGS_DIR, "model_calls.json")
 VERBOSE_MODE = False
 
 
@@ -160,3 +162,14 @@ def delete_global_prompt(name: str) -> None:
     path = _prompt_path(name)
     if os.path.exists(path):
         os.remove(path)
+
+
+def log_server_call(prompt: str) -> None:
+    """Prepend ``prompt`` to the server log list."""
+
+    os.makedirs(SERVER_LOGS_DIR, exist_ok=True)
+    data = load_json(MODEL_CALLS_PATH)
+    if not isinstance(data, list):
+        data = []
+    data.insert(0, prompt)
+    save_json(MODEL_CALLS_PATH, data)


### PR DESCRIPTION
## Summary
- log final prompt text rather than system/user pair
- remove system prompt from standard chat calls
- prepend prompts to server log file

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_684d2da66754832bb8c7e0774261b2de