### PR TITLE
Add prepared prompt logging

### DIFF
--- a/mythforge/call_core.py
+++ b/mythforge/call_core.py
@@ -20,6 +20,7 @@ from .utils import (
     CHATS_DIR,
     chat_file,
     load_global_prompts,
+    log_prepared_prompts,
 )
 from .memory import ChatHistoryService, MemoryManager, MEMORY_MANAGER
 
@@ -55,7 +56,9 @@ def build_call(req: "ChatRequest") -> CallData:
 
 # --- Background task queue -------------------------------------------------
 
-_task_queue: queue.Queue[tuple[str, Callable[..., None], tuple]] = queue.Queue()
+_task_queue: queue.Queue[tuple[str, Callable[..., None], tuple]] = (
+    queue.Queue()
+)
 _queued_types: set[str] = set()
 
 
@@ -216,7 +219,9 @@ def _maybe_generate_goals(
     setting = goals.setting
 
     state = _load_goal_state(chat_id)
-    state["messages_since_goal_eval"] = state.get("messages_since_goal_eval", 0) + 1
+    state["messages_since_goal_eval"] = (
+        state.get("messages_since_goal_eval", 0) + 1
+    )
 
     refresh = GENERATION_CONFIG.get("goal_refresh_rate", 1)
     if state["messages_since_goal_eval"] < refresh:
@@ -253,6 +258,8 @@ Do not include any explanation, commentary, or other text. If no goals are curre
 
     system_parts.append(textwrap.dedent(goal_prompt).strip())
     system_text = "\n".join(system_parts)
+
+    log_prepared_prompts("goal_generation", system_text, user_text)
 
     from .call_types import CALL_HANDLERS
     from .call_templates import goal_generation
@@ -322,7 +329,9 @@ def handle_chat(
 
     system_text, user_text = handler.prepare(call)
 
-    if call.chat_id != current_chat_id or system_text != (current_prompt or ""):
+    if call.chat_id != current_chat_id or system_text != (
+        current_prompt or ""
+    ):
         current_chat_id = call.chat_id
         current_prompt = system_text
 
@@ -373,7 +382,9 @@ def handle_chat(
 
         return StreamingResponse(_generate(), media_type="text/plain")
 
-    assistant_reply = processed if isinstance(processed, str) else str(processed)
+    assistant_reply = (
+        processed if isinstance(processed, str) else str(processed)
+    )
     _finalize_chat(
         assistant_reply,
         call,
@@ -398,7 +409,9 @@ class ChatRunner:
         self.current_chat_id: str | None = None
         self.current_prompt: str | None = None
 
-    def process_user_message(self, chat_id: str, message: str, stream: bool = False):
+    def process_user_message(
+        self, chat_id: str, message: str, stream: bool = False
+    ):
         call = CallData(chat_id=chat_id, message=message)
         result = handle_chat(
             call,

--- a/mythforge/call_templates/goal_generation.py
+++ b/mythforge/call_templates/goal_generation.py
@@ -4,6 +4,7 @@ from typing import Any, Iterable, Dict
 
 from ..call_core import CallData, _default_global_prompt
 from .. import memory
+from ..utils import log_prepared_prompts
 
 # -----------------------------------
 # Model launch parameters / arguments ORERRIDE
@@ -36,6 +37,7 @@ def prepare(call: CallData) -> tuple[str, str]:
     """Return prompts for goal generation calls."""
     system_text = prepare_system_text(call)
     user_text = prepare_user_text(call)
+    log_prepared_prompts(call.call_type, system_text, user_text)
     return system_text, user_text
 
 

--- a/mythforge/call_templates/logic_check.py
+++ b/mythforge/call_templates/logic_check.py
@@ -6,7 +6,7 @@ from typing import Any, Dict
 
 from ..model import _select_model_path
 from ..call_core import format_for_model, parse_response
-from ..utils import log_server_call
+from ..utils import log_server_call, log_prepared_prompts
 
 MODEL_LAUNCH_OVERRIDE: Dict[str, Any] = {
     "background": True,
@@ -49,8 +49,10 @@ def run_logic_check(system_text: str, user_text: str) -> str:
 
 def prepare(call: "CallData") -> tuple[str, str]:
     """Return prompts for ``call`` without modifications."""
-
-    return call.global_prompt, call.message
+    system_text = call.global_prompt
+    user_text = call.message
+    log_prepared_prompts(call.call_type, system_text, user_text)
+    return system_text, user_text
 
 
 def prompt(system_text: str, user_text: str) -> tuple[str, str]:

--- a/mythforge/call_templates/standard_chat.py
+++ b/mythforge/call_templates/standard_chat.py
@@ -11,7 +11,7 @@ from typing import TYPE_CHECKING
 from ..model import model_launch
 from .. import memory
 from ..call_core import format_for_model
-from ..utils import log_server_call
+from ..utils import log_server_call, log_prepared_prompts
 
 if TYPE_CHECKING:  # pragma: no cover - type checking only
     from ..call_core import CallData
@@ -203,6 +203,7 @@ def prepare(call: CallData) -> tuple[str, str]:
 
     system_text = prepare_system_text(call)
     user_text = prepare_user_text(history)
+    log_prepared_prompts(call.call_type, system_text, user_text)
     return system_text, user_text
 
 

--- a/mythforge/utils.py
+++ b/mythforge/utils.py
@@ -11,6 +11,7 @@ CHATS_DIR = os.path.join(ROOT_DIR, "chats")
 GLOBAL_PROMPTS_DIR = os.path.join(ROOT_DIR, "global_prompts")
 SERVER_LOGS_DIR = os.path.join(ROOT_DIR, "server_logs")
 MODEL_CALLS_PATH = os.path.join(SERVER_LOGS_DIR, "model_calls.json")
+PREPARED_CALLS_PATH = os.path.join(SERVER_LOGS_DIR, "prepared_prompts.json")
 
 
 def load_json(path: str) -> List[Any]:
@@ -145,3 +146,21 @@ def log_server_call(prompt: str) -> None:
         data = []
     data.insert(0, prompt)
     save_json(MODEL_CALLS_PATH, data)
+
+
+def log_prepared_prompts(
+    call_type: str, system_text: str, user_text: str
+) -> None:
+    """Prepend prepared prompt data to the server log list."""
+
+    os.makedirs(SERVER_LOGS_DIR, exist_ok=True)
+    data = load_json(PREPARED_CALLS_PATH)
+    if not isinstance(data, list):
+        data = []
+    entry = {
+        "call_type": call_type,
+        "system_text": system_text,
+        "user_text": user_text,
+    }
+    data.insert(0, entry)
+    save_json(PREPARED_CALLS_PATH, data)


### PR DESCRIPTION
## Summary
- log raw prompts to a new `prepared_prompts.json` file
- record prepared prompts in standard chat, goal generation and logic check
- capture goal generation prompt prep during background goal creation

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_684db6c107dc832ba24baad97946d969