### PR TITLE
Add console output for server logs

### DIFF
--- a/mythforge/utils.py
+++ b/mythforge/utils.py
@@ -138,7 +138,7 @@ def delete_global_prompt(name: str) -> None:
 
 
 def log_server_call(prompt: str) -> None:
-    """Prepend ``prompt`` to the server log list."""
+    """Prepend ``prompt`` to the server log list and print it."""
 
     os.makedirs(SERVER_LOGS_DIR, exist_ok=True)
     data = load_json(MODEL_CALLS_PATH)
@@ -146,12 +146,13 @@ def log_server_call(prompt: str) -> None:
         data = []
     data.insert(0, prompt)
     save_json(MODEL_CALLS_PATH, data)
+    print(prompt, flush=True)
 
 
 def log_prepared_prompts(
     call_type: str, system_text: str, user_text: str
 ) -> None:
-    """Prepend prepared prompt data to the server log list."""
+    """Prepend prepared prompt data to the server log list and print it."""
 
     os.makedirs(SERVER_LOGS_DIR, exist_ok=True)
     data = load_json(PREPARED_CALLS_PATH)
@@ -164,3 +165,4 @@ def log_prepared_prompts(
     }
     data.insert(0, entry)
     save_json(PREPARED_CALLS_PATH, data)
+    print(entry, flush=True)


### PR DESCRIPTION
## Summary
- print server logs and prepared prompt data to console

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q` *(fails: test_format_for_model_single_line)*

------
https://chatgpt.com/codex/tasks/task_e_684dde0bbcb4832ba07d0318d9c949ca