### PR TITLE
Centralize settings update logic

### DIFF
--- a/mythforge/model.py
+++ b/mythforge/model.py
@@ -15,16 +15,8 @@ ROOT_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
 MODELS_DIR = os.path.join(ROOT_DIR, "models")
 
 
-def load_model_settings(_path: str | None = None) -> Dict[str, object]:
-    """Return stored model settings using :class:`MemoryManager`."""
-
-    return MEMORY_MANAGER.load_settings()
-
-
-def save_model_settings(settings: Dict[str, object]) -> None:
-    """Persist ``settings`` via :class:`MemoryManager`."""
-
-    MEMORY_MANAGER.save_settings(settings)
+load_model_settings = MEMORY_MANAGER.load_settings
+save_model_settings = MEMORY_MANAGER.save_settings
 
 
 MODEL_SETTINGS = load_model_settings()
@@ -143,9 +135,7 @@ MODEL_LAUNCH_PARAMS: dict[str, object] = {
 }
 
 
-def model_launch(
-    prompt: str = "", background: bool = False, **overrides
-) -> list[str]:
+def model_launch(prompt: str = "", background: bool = False, **overrides) -> list[str]:
     """Return a command list for launching the model."""
 
     params = MODEL_LAUNCH_ARGS.copy()


### PR DESCRIPTION
## Summary
- wire API endpoints to MemoryManager CRUD
- expose simple load/save helpers in model layer
- consolidate settings handling in MemoryManager

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_684e0451a834832b8f9f4426c63beea4