### PR TITLE
Centralize logging with LoggerManager

### DIFF
--- a/mythforge/call_core.py
+++ b/mythforge/call_core.py
@@ -17,6 +17,7 @@ from .model import (
     call_llm,
 )
 from .memory import MemoryManager, MEMORY_MANAGER
+from .logger import LOGGER
 
 if TYPE_CHECKING:  # pragma: no cover - type checking only
     from .main import ChatRequest
@@ -107,16 +108,16 @@ def stream_parsed(chunks: Iterable[Any]) -> Iterator[str]:
 
 
 def format_for_model(system_text: str, user_text: str) -> str:
-    """Format system and user text using ChatML-style tokens."""
+    """Return CLI prompt string for ``system_text`` and ``user_text``."""
 
-    system_clean = system_text.strip().replace("\n", "/").replace('"', '\\"')
-    user_clean = user_text.strip().replace("\n", "/").replace('"', '\\"')
-
-    return (
-        f"<|im_start|>system\\{system_clean}<|im_end|>\\"
-        f"<|im_start|>user\\{user_clean}<|im_end|>\\"
-        f"<|im_start|>assistant\\/"
+    system_clean = system_text.replace("\n", " ").strip()
+    user_clean = user_text.replace("\n", " ").strip()
+    prompt = (
+        f"<|im_start|>{system_clean}<|im_end|>"
+        f"<|im_start|>user {user_clean}<|im_end|>"
+        f"<|im_start|>assistant"
     )
+    return f'--prompt "{prompt}"'
 
 
 # ---------------------------------------------------------------------------
@@ -228,7 +229,7 @@ Do not include any explanation, commentary, or other text. If no goals are curre
     system_parts.append(textwrap.dedent(goal_prompt).strip())
     system_text = "\n".join(system_parts)
 
-    memory.log_event(
+    LOGGER.log(
         "prepared_prompts",
         {
             "call_type": "goal_generation",

--- a/mythforge/call_templates/goal_generation.py
+++ b/mythforge/call_templates/goal_generation.py
@@ -5,6 +5,7 @@ from typing import Any, Iterable, Dict
 from ..call_core import CallData, _default_global_prompt
 from .. import memory
 from ..memory import MEMORY_MANAGER
+from ..logger import LOGGER
 
 # -----------------------------------
 # Model launch parameters / arguments ORERRIDE
@@ -37,7 +38,7 @@ def prepare(call: CallData) -> tuple[str, str]:
     """Return prompts for goal generation calls."""
     system_text = prepare_system_text(call)
     user_text = prepare_user_text(call)
-    MEMORY_MANAGER.log_event(
+    LOGGER.log(
         "prepared_prompts",
         {
             "call_type": call.call_type,

--- a/mythforge/call_templates/logic_check.py
+++ b/mythforge/call_templates/logic_check.py
@@ -7,6 +7,7 @@ from typing import Any, Dict
 from ..model import _select_model_path
 from ..call_core import format_for_model, parse_response
 from ..memory import MEMORY_MANAGER
+from ..logger import LOGGER
 
 MODEL_LAUNCH_OVERRIDE: Dict[str, Any] = {
     "background": True,
@@ -21,7 +22,7 @@ def send_prompt(system_text: str, user_text: str) -> dict[str, str]:
     from llama_cpp import Llama
 
     prompt = format_for_model(system_text, user_text)
-    MEMORY_MANAGER.log_event("model_calls", prompt)
+    LOGGER.log("model_calls", prompt)
 
     llm = Llama(
         model_path=_select_model_path(background=True),
@@ -51,7 +52,7 @@ def prepare(call: "CallData") -> tuple[str, str]:
     """Return prompts for ``call`` without modifications."""
     system_text = call.global_prompt
     user_text = call.message
-    MEMORY_MANAGER.log_event(
+    LOGGER.log(
         "prepared_prompts",
         {
             "call_type": call.call_type,

--- a/mythforge/call_templates/standard_chat.py
+++ b/mythforge/call_templates/standard_chat.py
@@ -12,6 +12,7 @@ from ..model import model_launch
 from .. import memory
 from ..call_core import format_for_model
 from ..memory import MEMORY_MANAGER
+from ..logger import LOGGER
 
 if TYPE_CHECKING:  # pragma: no cover - type checking only
     from ..call_core import CallData
@@ -113,7 +114,7 @@ def send_prompt(system_text: str, user_text: str, *, stream: bool = False):
     prep_standard_chat()
     _reset_timer()
     formatted_prompt = format_for_model(system_text, user_text)
-    MEMORY_MANAGER.log_event("model_calls", formatted_prompt)
+    LOGGER.log("model_calls", formatted_prompt)
     assert _chat_process is not None
     assert _chat_process.stdin is not None
     assert _chat_process.stdout is not None
@@ -143,7 +144,7 @@ def chat(chat_id: str, user_text: str) -> str:
     assert _chat_process is not None
     assert _chat_process.stdin is not None
     assert _chat_process.stdout is not None
-    MEMORY_MANAGER.log_event("model_calls", user_text)
+    LOGGER.log("model_calls", user_text)
     _chat_process.stdin.write(user_text + "\n")
     _chat_process.stdin.flush()
     output: list[str] = []
@@ -158,7 +159,7 @@ def send_cli_command(command: str, *, stream: bool = False):
     prep_standard_chat()
     _reset_timer()
     formatted_prompt = command
-    MEMORY_MANAGER.log_event("model_calls", formatted_prompt)
+    LOGGER.log("model_calls", formatted_prompt)
     assert _chat_process is not None
     assert _chat_process.stdin is not None
     assert _chat_process.stdout is not None
@@ -213,7 +214,7 @@ def prepare(call: CallData) -> tuple[str, str]:
 
     system_text = prepare_system_text(call)
     user_text = prepare_user_text(history)
-    MEMORY_MANAGER.log_event(
+    LOGGER.log(
         "prepared_prompts",
         {
             "call_type": call.call_type,

--- a/mythforge/logger.py
+++ b/mythforge/logger.py
@@ -1,0 +1,33 @@
+from __future__ import annotations
+
+"""Simple JSON file logger used across the project."""
+
+from typing import Any
+import os
+
+from .memory import MEMORY_MANAGER, _load_json, _save_json
+
+
+class LoggerManager:
+    """Persist log events under ``root_dir``."""
+
+    def __init__(self, root_dir: str) -> None:
+        self.root_dir = root_dir
+
+    def _path(self, name: str) -> str:
+        return os.path.join(self.root_dir, f"{name}.json")
+
+    def log(self, event_type: str, payload: Any) -> None:
+        os.makedirs(self.root_dir, exist_ok=True)
+        path = self._path(event_type)
+        data = _load_json(path)
+        if not isinstance(data, list):
+            data = []
+        data.insert(0, payload)
+        _save_json(path, data)
+
+    def log_error(self, err: Exception) -> None:
+        self.log("errors", {"error": str(err)})
+
+
+LOGGER = LoggerManager(MEMORY_MANAGER.logs_dir)

--- a/mythforge/main.py
+++ b/mythforge/main.py
@@ -135,12 +135,12 @@ def select_prompt(data: Dict[str, str]):
 
 
 @settings_router.get("/")
-def get_settings():
+def load_settings_endpoint():
     return memory_manager.load_settings()
 
 
 @settings_router.put("/")
-def update_settings(data: Dict[str, object]):
+def update_settings_endpoint(data: Dict[str, object]):
     updated = memory_manager.update_settings(data)
     return {"detail": "Updated", "settings": updated}
 
@@ -176,7 +176,7 @@ def create_chat(
 
 
 @chat_router.get("/{chat_id}/history")
-def get_history(
+def load_history_endpoint(
     chat_id: str,
     memory: MemoryManager = Depends(get_memory_manager),
 ):
@@ -186,7 +186,7 @@ def get_history(
 
 
 @chat_router.put("/{chat_id}/history/{index}")
-def edit_message(
+def save_message_endpoint(
     chat_id: str,
     index: int,
     data: Dict[str, str],
@@ -201,7 +201,7 @@ def edit_message(
 
 
 @chat_router.delete("/{chat_id}/history/{index}")
-def delete_message(
+def delete_message_endpoint(
     chat_id: str,
     index: int,
 ):

--- a/mythforge/memory.py
+++ b/mythforge/memory.py
@@ -200,15 +200,10 @@ class MemoryManager:
     # ------------------------------------------------------------------
     # Logging
     # ------------------------------------------------------------------
-    def log_event(self, event_type: str, payload: Any) -> None:
-        os.makedirs(self.logs_dir, exist_ok=True)
-        path = os.path.join(self.logs_dir, f"{event_type}.json")
-        data = self._read_json(path)
-        if not isinstance(data, list):
-            data = []
-        data.insert(0, payload)
-        self._write_json(path, data)
-        print(payload, flush=True)
+    def get_log_path(self, event_type: str) -> str:
+        """Return path for the ``event_type`` log file."""
+
+        return os.path.join(self.logs_dir, f"{event_type}.json")
 
     def update_paths(
         self, chat_name: str | None = None, prompt_name: str | None = None


### PR DESCRIPTION
## Summary
- add a new `LoggerManager` to handle event logging
- use `LOGGER.log` in call templates and core
- expose log path helper via `MemoryManager.get_log_path`
- rename several API endpoint functions using `load_` and `save_`
- adjust `format_for_model` to return CLI formatted prompt

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684e1365db6c832b83f7436ba5b56138