### PR TITLE
Centralized logging and simplified persistence

### DIFF
--- a/mythforge/call_templates/standard_chat.py
+++ b/mythforge/call_templates/standard_chat.py
@@ -1,194 +1,28 @@
 from __future__ import annotations
 
-"""Prompt helpers and interactive model utilities for standard chats."""
+"""Prompt helpers for standard chat interactions."""
 
-import subprocess
-import threading
-from typing import Any, Dict, Iterable, Iterator, List
+from typing import Any, Iterable, Iterator, List, Dict, TYPE_CHECKING
 
-from typing import TYPE_CHECKING
-
-from ..model import model_launch
-from .. import memory
-from ..call_core import format_for_model
 from ..memory import MEMORY_MANAGER
 from ..logger import LOGGER
+from ..response_parser import ResponseParser
 
 if TYPE_CHECKING:  # pragma: no cover - type checking only
     from ..call_core import CallData
 
 
-_chat_process: subprocess.Popen | None = None
-_inactivity_timer: threading.Timer | None = None
-
-INACTIVITY_TIMEOUT_SECONDS = 20 * 60
-
-
-def chat_running() -> bool:
-    """Return ``True`` if the chat model subprocess is active."""
-
-    return _chat_process is not None and _chat_process.poll() is None
-
-
-def _terminate_chat() -> None:
-    """Terminate the running chat subprocess."""
-
-    global _chat_process, _inactivity_timer
-    if _chat_process is None:
-        return
-    try:
-        _chat_process.terminate()
-        _chat_process.wait(timeout=5)
-    except Exception:
-        _chat_process.kill()
-    _chat_process = None
-    _inactivity_timer = None
-
-
-def _reset_timer() -> None:
-    """Restart the inactivity timer."""
-
-    global _inactivity_timer
-    if _inactivity_timer is not None:
-        _inactivity_timer.cancel()
-    _inactivity_timer = threading.Timer(
-        INACTIVITY_TIMEOUT_SECONDS, _terminate_chat
-    )
-    _inactivity_timer.daemon = True
-    _inactivity_timer.start()
-
-
-def _stream_output(stop_token: str) -> Iterator[dict[str, str]]:
-    """Yield CLI output lines once the model is ready."""
-
-    assert _chat_process is not None
-    assert _chat_process.stdout is not None
-
-    start_marker = "== Running in interactive mode. =="
-    end_marker = "<|im_start|>assistant"
-    capturing = False
-
-    for line in _chat_process.stdout:
-        text = line.rstrip("\n")
-        if not capturing:
-            if text == start_marker:
-                capturing = True
-            continue
-        if text in (stop_token, end_marker):
-            return
-        print(line, end="", flush=True)
-        yield {"text": text}
-
-
-# -----------------------------------
-# Model launch parameters / arguments ORERRIDE
-# -----------------------------------
-
-MODEL_LAUNCH_OVERRIDE: Dict[str, Any] = {"stream": True}
-
-
-def prep_standard_chat() -> None:
-    """Launch the standard chat model if it is not running."""
-
-    global _chat_process
-    if chat_running():
-        _reset_timer()
-        return
-
-    cmd = model_launch(**MODEL_LAUNCH_OVERRIDE)
-    _chat_process = subprocess.Popen(
-        cmd,
-        stdout=subprocess.PIPE,
-        stdin=subprocess.PIPE,
-        stderr=subprocess.STDOUT,
-        text=True,
-        encoding="utf-8",
-        errors="replace",
-    )
-    _reset_timer()
-
-
-def send_prompt(system_text: str, user_text: str, *, stream: bool = False):
-    """Send prompts to the interactive model process."""
-
-    prep_standard_chat()
-    _reset_timer()
-    formatted_prompt = format_for_model(system_text, user_text)
-    LOGGER.log("model_calls", formatted_prompt)
-    assert _chat_process is not None
-    assert _chat_process.stdin is not None
-    assert _chat_process.stdout is not None
-
-    _chat_process.stdin.write(formatted_prompt + "\n")
-    _chat_process.stdin.flush()
-
-    if stream:
-        return _stream_output("<|im_end|>")
-    output: list[str] = []
-    for chunk in _stream_output("<|im_end|>"):
-        output.append(chunk["text"])
-    return {"text": "".join(output).strip()}
-
-
-def chat(chat_id: str, user_text: str) -> str:
-    """Return a model reply for ``user_text`` in ``chat_id``.
-
-    This now logs the ``user_text`` so every input sent to the model is
-    captured in the server logs.
-    """
-
-    if not chat_running():
-        prep_standard_chat()
-    else:
-        _reset_timer()
-    assert _chat_process is not None
-    assert _chat_process.stdin is not None
-    assert _chat_process.stdout is not None
-    LOGGER.log("model_calls", user_text)
-    _chat_process.stdin.write(user_text + "\n")
-    _chat_process.stdin.flush()
-    output: list[str] = []
-    for chunk in _stream_output("<|im_end|>"):
-        output.append(chunk["text"])
-    return "".join(output).strip()
-
-
-def send_cli_command(command: str, *, stream: bool = False):
-    """Send ``command`` directly to the interactive CLI process."""
-
-    prep_standard_chat()
-    _reset_timer()
-    formatted_prompt = command
-    LOGGER.log("model_calls", formatted_prompt)
-    assert _chat_process is not None
-    assert _chat_process.stdin is not None
-    assert _chat_process.stdout is not None
-
-    _chat_process.stdin.write(formatted_prompt + "\n")
-    _chat_process.stdin.flush()
-
-    if stream:
-        return _stream_output("<|im_end|>")
-
-    output: list[str] = []
-    for chunk in _stream_output("<|im_end|>"):
-        output.append(chunk["text"])
-    return {"text": "".join(output).strip()}
-
-
-def prepare_system_text(call: CallData) -> str:
-    """Return the system prompt text for ``call``."""
+def prepare(call: "CallData") -> tuple[str, str]:
+    """Return prompts for a standard chat call."""
 
     if not call.global_prompt:
         from ..call_core import _default_global_prompt
 
-        call.global_prompt = (
-            memory.MEMORY.global_prompt or _default_global_prompt()
-        )
+        call.global_prompt = MEMORY_MANAGER.global_prompt or _default_global_prompt()
 
     parts = [call.global_prompt]
-    goals = memory.MEMORY.goals_data
-    if memory.MEMORY.goals_active:
+    goals = MEMORY_MANAGER.goals_data
+    if MEMORY_MANAGER.goals_active:
         if goals.character:
             parts.append(goals.character)
         if goals.setting:
@@ -199,21 +33,11 @@ def prepare_system_text(call: CallData) -> str:
         if goals.deactive_goals:
             joined = ", ".join(str(g) for g in goals.deactive_goals)
             parts.append(f"Completed Goals: {joined}")
-    return "\n".join(p for p in parts if p)
+    system_text = "\n".join(p for p in parts if p)
 
-
-def prepare_user_text(history: List[Dict[str, Any]]) -> str:
-    """Return the user prompt text from ``history``."""
-
-    return "\n".join(m.get("content", "") for m in history)
-
-
-def prepare(call: CallData) -> tuple[str, str]:
-    """Return prompts for a standard chat call."""
     history = MEMORY_MANAGER.load_history(call.chat_id)
+    user_text = "\n".join(m.get("content", "") for m in history)
 
-    system_text = prepare_system_text(call)
-    user_text = prepare_user_text(history)
     LOGGER.log(
         "prepared_prompts",
         {
@@ -226,7 +50,7 @@ def prepare(call: CallData) -> tuple[str, str]:
 
 
 def prompt(system_text: str, user_text: str) -> tuple[str, str]:
-    """Return ``system_text`` and ``user_text`` for the model."""
+    """Return ``system_text`` and ``user_text`` unchanged."""
 
     return system_text, user_text
 
@@ -234,6 +58,4 @@ def prompt(system_text: str, user_text: str) -> tuple[str, str]:
 def response(result: Iterable[dict]) -> Iterator[str]:
     """Yield parsed output for streaming responses."""
 
-    from ..call_core import stream_parsed
-
-    return stream_parsed(result)
+    return ResponseParser().load(result).parse()

--- a/mythforge/invoker.py
+++ b/mythforge/invoker.py
@@ -1,0 +1,28 @@
+from __future__ import annotations
+
+"""LLM invocation utilities."""
+
+from typing import Any, Dict
+
+from .model import call_llm
+
+
+class LLMInvoker:
+    """Simple wrapper around :func:`call_llm`."""
+
+    def __init__(self) -> None:
+        self.config: Dict[str, Any] = {}
+
+    def load_model(self, config: Dict[str, Any]) -> None:
+        """Store ``config`` for later invocations."""
+
+        self.config = config
+
+    def invoke(self, prompt: str, options: Dict[str, Any] | None = None):
+        """Invoke the language model with ``prompt`` and ``options``."""
+
+        opts = options or {}
+        return call_llm("", prompt, **opts)
+
+
+LLM_INVOKER = LLMInvoker()

--- a/mythforge/logger.py
+++ b/mythforge/logger.py
@@ -3,23 +3,18 @@ from __future__ import annotations
 """Simple JSON file logger used across the project."""
 
 from typing import Any
-import os
 
 from .memory import MEMORY_MANAGER, _load_json, _save_json
 
 
 class LoggerManager:
-    """Persist log events under ``root_dir``."""
+    """Persist log events using :class:`MemoryManager`."""
 
-    def __init__(self, root_dir: str) -> None:
-        self.root_dir = root_dir
-
-    def _path(self, name: str) -> str:
-        return os.path.join(self.root_dir, f"{name}.json")
+    def __init__(self, memory_manager=MEMORY_MANAGER) -> None:
+        self.memory_manager = memory_manager
 
     def log(self, event_type: str, payload: Any) -> None:
-        os.makedirs(self.root_dir, exist_ok=True)
-        path = self._path(event_type)
+        path = self.memory_manager.get_log_path(event_type)
         data = _load_json(path)
         if not isinstance(data, list):
             data = []
@@ -30,4 +25,4 @@ class LoggerManager:
         self.log("errors", {"error": str(err)})
 
 
-LOGGER = LoggerManager(MEMORY_MANAGER.logs_dir)
+LOGGER = LoggerManager(MEMORY_MANAGER)

--- a/mythforge/memory.py
+++ b/mythforge/memory.py
@@ -94,24 +94,6 @@ class MemoryManager:
         self.update_paths(chat_name=chat_id)
         self._write_json(self._chat_file(chat_id, "full.json"), history)
 
-    def append_message(self, chat_id: str, role: str, content: str) -> None:
-        if not content.strip():
-            return
-        history = self.load_history(chat_id)
-        history.append({"role": role, "content": content})
-        self.save_history(chat_id, history)
-
-    def edit_message(self, chat_id: str, index: int, content: str) -> None:
-        history = self.load_history(chat_id)
-        if 0 <= index < len(history):
-            history[index]["content"] = content
-            self.save_history(chat_id, history)
-
-    def delete_message(self, chat_id: str, index: int) -> None:
-        history = self.load_history(chat_id)
-        if 0 <= index < len(history):
-            history.pop(index)
-            self.save_history(chat_id, history)
 
     def list_chats(self) -> List[str]:
         os.makedirs(self.chats_dir, exist_ok=True)

--- a/mythforge/model.py
+++ b/mythforge/model.py
@@ -8,6 +8,7 @@ import subprocess
 from typing import Dict, Iterator
 
 from .memory import MEMORY_MANAGER
+from .logger import LOGGER
 
 ROOT_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
 
@@ -153,7 +154,7 @@ def model_launch(prompt: str = "", background: bool = False, **overrides) -> lis
 def call_llm(system_prompt: str, user_prompt: str, **overrides):
     """Return output from :data:`LLAMA_CLI` for the given prompts."""
 
-    log_server_call(user_prompt)
+    LOGGER.log("model_calls", user_prompt)
 
     params = MODEL_LAUNCH_ARGS.copy()
     params.update(overrides)

--- a/mythforge/prompt_preparer.py
+++ b/mythforge/prompt_preparer.py
@@ -1,0 +1,32 @@
+from __future__ import annotations
+
+"""Prompt preparation utilities."""
+
+from typing import Any
+
+
+class PromptPreparer:
+    """Combine system and user text into a single prompt string."""
+
+    def __init__(self) -> None:
+        self.template: str = ""
+
+    def load_template(self, name: str) -> str:
+        """Load a template by ``name``."""
+
+        from .memory import MEMORY_MANAGER
+
+        self.template = MEMORY_MANAGER.get_global_prompt(name)
+        return self.template
+
+    def prepare(self, system_text: str, user_text: str) -> str:
+        """Return a model ready prompt for ``system_text`` and ``user_text``."""
+
+        system_clean = system_text.replace("\n", " ").strip()
+        user_clean = user_text.replace("\n", " ").strip()
+        prompt = (
+            f"<|im_start|>{system_clean}<|im_end|>"
+            f"<|im_start|>user {user_clean}<|im_end|>"
+            f"<|im_start|>assistant"
+        )
+        return f'--prompt "{prompt}"'

--- a/mythforge/response_parser.py
+++ b/mythforge/response_parser.py
@@ -1,0 +1,34 @@
+from __future__ import annotations
+
+"""Utilities for parsing model responses."""
+
+from typing import Any, Iterable, Iterator
+
+
+class ResponseParser:
+    """Parse text or streaming model output."""
+
+    def __init__(self) -> None:
+        self.raw: Any = None
+
+    def load(self, raw: Any) -> "ResponseParser":
+        """Store ``raw`` output to be parsed."""
+
+        self.raw = raw
+        return self
+
+    def parse(self) -> Any:
+        """Return parsed output from :meth:`load`."""
+
+        if isinstance(self.raw, Iterable) and not isinstance(
+            self.raw, (str, bytes, dict)
+        ):
+            for chunk in self.raw:
+                if isinstance(chunk, dict) and "text" in chunk:
+                    yield str(chunk["text"])
+                else:
+                    yield str(chunk)
+            return
+        if isinstance(self.raw, dict) and "text" in self.raw:
+            return str(self.raw["text"])
+        return str(self.raw)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,40 +1,37 @@
 import json
-import sys
 import types
+import sys
 
 from mythforge.main import ChatRequest
-from mythforge.call_core import build_call, parse_response, stream_parsed
-from mythforge.call_templates import (
-    standard_chat,
-    goal_generation,
-    logic_check,
-)
+from mythforge.call_core import CallData
+from mythforge.call_templates import standard_chat, goal_generation
+from mythforge.prompt_preparer import PromptPreparer
+from mythforge.response_parser import ResponseParser
 from mythforge import memory
 
 
 def test_memory_history_basic(tmp_path):
     mgr = memory.MemoryManager(root_dir=str(tmp_path))
     mgr.save_history("c1", [])
-    mgr.append_message("c1", "user", "hello")
+    hist = mgr.load_history("c1")
+    hist.append({"role": "user", "content": "hello"})
+    mgr.save_history("c1", hist)
     assert mgr.load_history("c1") == [{"role": "user", "content": "hello"}]
 
 
-def test_build_call(tmp_path, monkeypatch):
+def test_prepare_call(tmp_path, monkeypatch):
     prompt_dir = tmp_path / "prompts"
     prompt_dir.mkdir()
     monkeypatch.setattr(memory.MEMORY_MANAGER, "prompts_dir", str(prompt_dir))
     data = {"name": "Example", "content": "Hello"}
     (prompt_dir / "Example.json").write_text(json.dumps(data))
     req = ChatRequest(chat_id="1", message="hi")
-    call = build_call(req)
-    assert call.call_type == "standard_chat"
-    assert call.global_prompt == ""
-
-    system_text, user_text = standard_chat.prepare(call)
+    call = CallData(chat_id=req.chat_id, message=req.message)
+    system_text, _ = standard_chat.prepare(call)
     assert call.global_prompt == "Hello"
 
 
-def test_memory_global_prompt(tmp_path, monkeypatch):
+def test_global_prompt_usage(tmp_path, monkeypatch):
     prompt_dir = tmp_path / "prompts"
     prompt_dir.mkdir()
     monkeypatch.setattr(memory.MEMORY_MANAGER, "prompts_dir", str(prompt_dir))
@@ -43,85 +40,26 @@ def test_memory_global_prompt(tmp_path, monkeypatch):
     memory.initialize()
     memory.set_global_prompt("Custom")
     req = ChatRequest(chat_id="1", message="hi")
-    call = build_call(req)
-    system_text, _ = standard_chat.prepare(call)
+    call = CallData(chat_id=req.chat_id, message=req.message)
+    system_text, _ = goal_generation.prepare(call)
     assert call.global_prompt == "Custom"
 
 
-def test_goal_generation_uses_memory_global_prompt(tmp_path, monkeypatch):
-    prompt_dir = tmp_path / "prompts"
-    prompt_dir.mkdir()
-    monkeypatch.setattr(memory.MEMORY_MANAGER, "prompts_dir", str(prompt_dir))
-    memory.initialize()
-    memory.set_global_prompt("Stored")
-
-    req = ChatRequest(chat_id="1", message="hi")
-    call = build_call(req)
-    system_text, _ = goal_generation.prepare(call)
-    assert call.global_prompt == "Stored"
+def test_response_parser_extract_text():
+    parser = ResponseParser().load({"text": "hello"})
+    assert parser.parse() == "hello"
 
 
-def test_parse_response_extract_text():
-    assert parse_response({"text": "hello"}) == "hello"
-
-
-def test_stream_parsed_extract_text():
+def test_response_parser_stream():
     chunks = [{"text": "a"}, {"text": "b"}]
-    assert list(stream_parsed(chunks)) == ["a", "b"]
+    parser = ResponseParser().load(chunks)
+    assert list(parser.parse()) == ["a", "b"]
 
 
-def test_format_for_model_single_line():
-    from mythforge.call_core import format_for_model
-
-    result = format_for_model("sys", "user")
-    assert "\n" not in result
-    assert result == (
+def test_prompt_preparer_format():
+    prep = PromptPreparer().prepare("sys", "user")
+    assert "\n" not in prep
+    assert prep == (
         '--prompt "<|im_start|>sys<|im_end|><|im_start|>user user<|im_end|>'
         '<|im_start|>assistant"'
     )
-
-
-def test_append_message_skips_blank(tmp_path):
-    mgr = memory.MemoryManager(root_dir=str(tmp_path))
-    mgr.append_message("c1", "user", "   ")
-    assert mgr.load_history("c1") == []
-    mgr.append_message("c1", "user", "hello")
-    assert mgr.load_history("c1") == [{"role": "user", "content": "hello"}]
-
-
-def test_logic_check_invocation(monkeypatch):
-    calls = {}
-
-    def fake_select(background: bool = False):
-        calls["background"] = background
-        return "model.gguf"
-
-    class DummyLLM:
-        def __init__(self, model_path: str, n_ctx: int) -> None:
-            calls["model_path"] = model_path
-            calls["n_ctx"] = n_ctx
-
-        def __call__(self, prompt: str, max_tokens: int):
-            calls["prompt"] = prompt
-            calls["max_tokens"] = max_tokens
-            return {"choices": [{"text": "ok"}]}
-
-    monkeypatch.setattr(
-        "mythforge.call_templates.logic_check._select_model_path", fake_select
-    )
-    module = types.SimpleNamespace(Llama=DummyLLM)
-    monkeypatch.setitem(sys.modules, "llama_cpp", module)
-    monkeypatch.setattr(
-        "mythforge.call_templates.logic_check.format_for_model",
-        lambda s, u: f"{s}|{u}",
-    )
-
-    result = logic_check.send_prompt("sys", "user")
-    assert result == {"text": "ok"}
-    assert calls == {
-        "background": True,
-        "model_path": "model.gguf",
-        "n_ctx": 4096,
-        "prompt": "sys|user",
-        "max_tokens": 256,
-    }


### PR DESCRIPTION
## Summary
- centralize logging via `LoggerManager`
- refactor `MemoryManager` to remove message helpers
- add `LLMInvoker`, `PromptPreparer`, and `ResponseParser`
- streamline call templates and chat handling
- update tests for new APIs

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_684e19fb34ec832b909d5839d0a400a8