### PR TITLE
Adjust prompt handling and logging

### DIFF
--- a/mythforge/call_templates/logic_check.py
+++ b/mythforge/call_templates/logic_check.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 """Prompt helpers for logic checking utilities."""
 
-from typing import Any, Dict
+from typing import Any, Dict, Iterator
 
 from ..prompt_preparer import PromptPreparer
 from ..response_parser import ResponseParser
@@ -23,7 +23,18 @@ MODEL_LAUNCH_OVERRIDE: Dict[str, Any] = {
 def logic_check(global_prompt: str, message: str, options: Dict[str, Any]):
     """Return parsed logic check result."""
 
-    system, user = PromptPreparer().prepare(global_prompt, message)
-    raw = LLMInvoker().invoke(system, options)
-    result = ResponseParser().load(raw).parse()
-    return result
+    prepared = PromptPreparer().prepare(global_prompt, message)
+    raw = LLMInvoker().invoke(prepared, options)
+    parsed = ResponseParser().load(raw).parse()
+    if isinstance(parsed, Iterator):
+        try:
+            first = next(parsed)
+        except StopIteration as exc:  # pragma: no cover - best effort
+            return str(exc.value)
+
+        def _chain() -> Iterator[str]:
+            yield first
+            yield from parsed
+
+        return _chain()
+    return parsed

--- a/mythforge/model.py
+++ b/mythforge/model.py
@@ -8,7 +8,6 @@ import subprocess
 from typing import Dict, Iterator
 
 from .memory import MEMORY_MANAGER
-from .logger import LOGGER
 
 ROOT_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
 
@@ -154,7 +153,6 @@ def model_launch(prompt: str = "", background: bool = False, **overrides) -> lis
 def call_llm(system_prompt: str, user_prompt: str, **overrides):
     """Return output from :data:`LLAMA_CLI` for the given prompts."""
 
-    LOGGER.log("model_calls", user_prompt)
 
     params = MODEL_LAUNCH_ARGS.copy()
     params.update(overrides)


### PR DESCRIPTION
## Summary
- log JSON load errors via `LoggerManager`
- simplify `call_llm` to avoid noisy logging
- ensure call templates work with single-string prompts
- alias `prep_standard_chat` for backward compatibility
- load `model` lazily to prevent circular imports

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q tests/test_utils.py::test_prepare_call`
- `pytest -q tests/test_utils.py::test_global_prompt_usage`


------
https://chatgpt.com/codex/tasks/task_e_684e39d6ef54832b8dffb1c9d42b4365