### PR TITLE
Streamline chat endpoint and add escaping tests

### DIFF
--- a/mythforge/prompt_preparer.py
+++ b/mythforge/prompt_preparer.py
@@ -22,8 +22,10 @@ class PromptPreparer:
     def prepare(self, system_text: str, user_text: str) -> str:
         """Return a model ready prompt for ``system_text`` and ``user_text``."""
 
-        system_clean = system_text.replace("\n", " ").strip()
-        user_clean = user_text.replace("\n", " ").strip()
+        system_clean = (
+            system_text.replace("\n", " ").replace('"', '\\"').strip()
+        )
+        user_clean = user_text.replace("\n", " ").replace('"', '\\"').strip()
         prompt = (
             f"<|im_start|>{system_clean}<|im_end|>"
             f"<|im_start|>user {user_clean}<|im_end|>"

--- a/mythforge/response_parser.py
+++ b/mythforge/response_parser.py
@@ -23,12 +23,15 @@ class ResponseParser:
         if isinstance(self.raw, Iterable) and not isinstance(
             self.raw, (str, bytes, dict)
         ):
-            for chunk in self.raw:
-                if isinstance(chunk, dict) and "text" in chunk:
-                    yield str(chunk["text"])
-                else:
-                    yield str(chunk)
-            return
+
+            def _iter() -> Iterator[str]:
+                for chunk in self.raw:
+                    if isinstance(chunk, dict) and "text" in chunk:
+                        yield str(chunk["text"])
+                    else:
+                        yield str(chunk)
+
+            return _iter()
         if isinstance(self.raw, dict) and "text" in self.raw:
             return str(self.raw["text"])
         return str(self.raw)

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -27,7 +27,7 @@ def test_llm_invoker_invoke(monkeypatch):
     def fake_call(system, prompt, **opts):
         return {"text": "done"}
 
-    monkeypatch.setattr(model, "call_llm", fake_call)
+    monkeypatch.setattr("mythforge.invoker.call_llm", fake_call)
     inv = LLMInvoker()
     assert inv.invoke("prompt") == {"text": "done"}
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -19,7 +19,9 @@ def test_memory_history_basic(tmp_path):
 
 
 def test_prepare_call(monkeypatch):
-    call = CallData(chat_id="1", message="hi", global_prompt="Hello", options={})
+    call = CallData(
+        chat_id="1", message="hi", global_prompt="Hello", options={}
+    )
 
     invoked = {}
 
@@ -31,15 +33,21 @@ def test_prepare_call(monkeypatch):
 
     result = standard_chat.prepare_and_chat(call)
     assert result == "ok"
-    assert invoked["prompt"].startswith('--prompt')
+    assert invoked["prompt"].startswith("--prompt")
 
 
 def test_global_prompt_usage(monkeypatch):
-    call = CallData(chat_id="1", message="hi", global_prompt="Custom", options={})
+    call = CallData(
+        chat_id="1", message="hi", global_prompt="Custom", options={}
+    )
 
-    monkeypatch.setattr(LLMInvoker, "invoke", lambda self, prompt, opts=None: {"text": "ok"})
+    monkeypatch.setattr(
+        LLMInvoker, "invoke", lambda self, prompt, opts=None: {"text": "ok"}
+    )
 
-    result = goal_generation.generate_goals(call.global_prompt, call.message, {})
+    result = goal_generation.generate_goals(
+        call.global_prompt, call.message, {}
+    )
     assert result == "ok"
 
 
@@ -54,6 +62,12 @@ def test_response_parser_stream():
     assert list(parser.parse()) == ["a", "b"]
 
 
+def test_response_parser_stream_dicts():
+    chunks = [{"text": "hello"}, {"text": "world"}]
+    parsed = ResponseParser().load(chunks).parse()
+    assert list(parsed) == ["hello", "world"]
+
+
 def test_prompt_preparer_format():
     prep = PromptPreparer().prepare("sys", "user")
     assert "\n" not in prep
@@ -61,3 +75,9 @@ def test_prompt_preparer_format():
         '--prompt "<|im_start|>sys<|im_end|><|im_start|>user user<|im_end|>'
         '<|im_start|>assistant"'
     )
+
+
+def test_prompt_preparer_escaping():
+    prep = PromptPreparer().prepare('s "s"', 'u "u" <x>')
+    assert '\\"' in prep
+    assert '<|im_start|>user u \\"u\\" <x><|im_end|>' in prep


### PR DESCRIPTION
## Summary
- remove unused `prep_standard_chat` call at startup
- consolidate chat endpoints into `/chats/{chat_id}/message`
- escape quotes in `PromptPreparer.prepare`
- make `ResponseParser.parse` return a generator only for streams
- update unit tests for new behavior and add coverage

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684e43eb96a0832bbc649a27931f4594