### PR TITLE
Fix prompt deletion selection

### DIFF
--- a/ui/MythForgeUI.html
+++ b/ui/MythForgeUI.html
@@ -1041,10 +1041,11 @@
                     if(!res.ok){ const j=await res.json(); throw new Error(j.detail||'Server error'); }
                     await refreshGlobalPromptList();
                     if(state.currentPrompt===name){
-                        state.currentPrompt = state.prompts.length? state.prompts[0]:'';
-                        localStorage.setItem('lastGlobalPrompt', state.currentPrompt);
+                        const next = state.prompts.length ? state.prompts[0] : '';
+                        await selectPrompt(next);
+                    }else{
+                        renderPromptList();
                     }
-                    renderPromptList();
                 }catch(e){ alert('Failed to delete prompt: '+e.message); }
             });
         }


### PR DESCRIPTION
## Summary
- call `selectPrompt` after deleting a prompt so the server updates to the new selection

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_684e4994f21c832bb277ae80cae811a0