### PR TITLE
Add logging across chat pipeline

### DIFF
--- a/mythforge/call_core.py
+++ b/mythforge/call_core.py
@@ -147,6 +147,13 @@ def _maybe_generate_goals(
     global_prompt: str,
     memory: MemoryManager = MEMORY_MANAGER,
 ) -> None:
+    LOGGER.log(
+        "chat_flow",
+        {
+            "function": "_maybe_generate_goals",
+            "chat_id": chat_id,
+        },
+    )
     goals = memory.load_goals(chat_id)
     if not memory.goals_active:
         return
@@ -238,6 +245,14 @@ def _finalize_chat(
 ) -> None:
     """Store assistant reply and queue background work."""
 
+    LOGGER.log(
+        "chat_flow",
+        {
+            "function": "_finalize_chat",
+            "chat_id": call.chat_id,
+        },
+    )
+
     history = memory.load_history(call.chat_id)
     history.append({"role": "assistant", "content": reply})
     memory.save_history(call.chat_id, history)
@@ -259,6 +274,14 @@ def handle_chat(
     current_prompt: str | None = None,
 ):
     """Process ``call`` and return a model reply."""
+
+    LOGGER.log(
+        "chat_flow",
+        {
+            "function": "handle_chat",
+            "chat_id": current_chat_id or call.chat_id,
+        },
+    )
 
     from .call_templates import standard_chat, logic_check
 
@@ -318,6 +341,13 @@ class ChatRunner:
     def process_user_message(
         self, chat_id: str, message: str, stream: bool = False
     ):
+        LOGGER.log(
+            "chat_flow",
+            {
+                "function": "ChatRunner.process_user_message",
+                "chat_id": chat_id,
+            },
+        )
         call = CallData(chat_id=chat_id, message=message, options={"stream": stream})
         result = handle_chat(
             call,

--- a/mythforge/call_templates/standard_chat.py
+++ b/mythforge/call_templates/standard_chat.py
@@ -9,6 +9,7 @@ from typing import Iterator
 from ..response_parser import ResponseParser
 from ..prompt_preparer import PromptPreparer
 from ..invoker import LLMInvoker
+from ..logger import LOGGER
 
 if TYPE_CHECKING:  # pragma: no cover - type checking only
     from ..call_core import CallData
@@ -16,6 +17,14 @@ if TYPE_CHECKING:  # pragma: no cover - type checking only
 
 def prepare_and_chat(call: "CallData"):
     """Return parsed chat output for ``call``."""
+
+    LOGGER.log(
+        "chat_flow",
+        {
+            "function": "prepare_and_chat",
+            "chat_id": call.chat_id,
+        },
+    )
 
     prepared = PromptPreparer().prepare(call.global_prompt, call.message)
     raw = LLMInvoker().invoke(prepared, call.options)

--- a/mythforge/invoker.py
+++ b/mythforge/invoker.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 from typing import Any, Dict
 
+from .logger import LOGGER
+
 from .model import call_llm
 
 
@@ -21,6 +23,12 @@ class LLMInvoker:
     def invoke(self, prompt: str, options: Dict[str, Any] | None = None):
         """Invoke the language model with ``prompt`` and ``options``."""
 
+        LOGGER.log(
+            "chat_flow",
+            {
+                "function": "LLMInvoker.invoke",
+            },
+        )
         opts = options or {}
         return call_llm("", prompt, **opts)
 

--- a/mythforge/main.py
+++ b/mythforge/main.py
@@ -17,6 +17,7 @@ from .memory import (
 from .call_core import ChatRunner
 from .prompt_preparer import PromptPreparer
 from .invoker import LLMInvoker
+from .logger import LOGGER
 
 app = FastAPI(title="MythForgeUI", debug=False)
 
@@ -344,6 +345,14 @@ def send_chat_message(
     runner: ChatRunner = Depends(lambda: chat_runner),
 ):
     """Stream a reply for ``req.message`` using the standard chat model."""
+
+    LOGGER.log(
+        "chat_flow",
+        {
+            "function": "send_chat_message",
+            "chat_id": chat_id,
+        },
+    )
 
     history = memory_manager.load_history(chat_id)
     history.append({"role": "user", "content": req.message})

--- a/mythforge/prompt_preparer.py
+++ b/mythforge/prompt_preparer.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 from typing import Any
 
+from .logger import LOGGER
+
 
 class PromptPreparer:
     """Combine system and user text into a single prompt string."""
@@ -21,6 +23,13 @@ class PromptPreparer:
 
     def prepare(self, system_text: str, user_text: str) -> str:
         """Return a model ready prompt for ``system_text`` and ``user_text``."""
+
+        LOGGER.log(
+            "chat_flow",
+            {
+                "function": "PromptPreparer.prepare",
+            },
+        )
 
         system_clean = (
             system_text.replace("\n", " ").replace('"', '\\"').strip()

--- a/mythforge/response_parser.py
+++ b/mythforge/response_parser.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 from typing import Any, Iterable, Iterator
 
+from .logger import LOGGER
+
 
 class ResponseParser:
     """Parse text or streaming model output."""
@@ -14,11 +16,24 @@ class ResponseParser:
     def load(self, raw: Any) -> "ResponseParser":
         """Store ``raw`` output to be parsed."""
 
+        LOGGER.log(
+            "chat_flow",
+            {
+                "function": "ResponseParser.load",
+            },
+        )
         self.raw = raw
         return self
 
     def parse(self) -> Any:
         """Return parsed output from :meth:`load`."""
+
+        LOGGER.log(
+            "chat_flow",
+            {
+                "function": "ResponseParser.parse",
+            },
+        )
 
         if isinstance(self.raw, Iterable) and not isinstance(
             self.raw, (str, bytes, dict)


### PR DESCRIPTION
## Summary
- log at each step of the chat pipeline for easier troubleshooting
- include logger in chat endpoint, chat runner, chat handler, and support classes

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_684e5e1898ac832bb40e6469238ce7bb