### PR TITLE
Add goal check logging

### DIFF
--- a/mythforge/call_core.py
+++ b/mythforge/call_core.py
@@ -159,6 +159,15 @@ def _maybe_generate_goals(
     )
 
     refresh = GENERATION_CONFIG.get("goal_refresh_rate", 1)
+    LOGGER.log(
+        "goal_state_check",
+        {
+            "chat_id": chat_id,
+            "current": state["messages_since_goal_eval"],
+            "refresh_rate": refresh,
+            "generate": state["messages_since_goal_eval"] >= refresh,
+        },
+    )
     if state["messages_since_goal_eval"] < refresh:
         memory.save_goal_state(chat_id, state)
         return


### PR DESCRIPTION
## Summary
- log goal state checks at the start of `_maybe_generate_goals`

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_684e5f68b874832b902bbc32e8f06d06