### PR TITLE
Refactor context handling

### DIFF
--- a/mythforge/call_core.py
+++ b/mythforge/call_core.py
@@ -29,7 +29,7 @@ if TYPE_CHECKING:  # pragma: no cover - type checking only
 class CallData:
     """Container for information used when calling the model."""
 
-    chat_id: str
+    chat_name: str
     message: str
     global_prompt: str = ""
     call_type: str = "standard_chat"
@@ -139,7 +139,7 @@ def _dedupe_new_goals(
 
 
 def _maybe_generate_goals(
-    chat_id: str,
+    chat_name: str,
     global_prompt: str,
     memory: MemoryManager = MEMORY_MANAGER,
 ) -> None:
@@ -147,18 +147,18 @@ def _maybe_generate_goals(
         "chat_flow",
         {
             "function": "_maybe_generate_goals",
-            "chat_id": chat_id,
+            "chat_name": chat_name,
             "global_prompt": global_prompt,
             "memory_root": memory.root_dir,
         },
     )
-    goals = memory.load_goals(chat_id)
+    goals = memory.load_goals(chat_name)
     if not memory.goals_active:
         return
     character = goals.character
     setting = goals.setting
 
-    state = memory.load_goal_state(chat_id)
+    state = memory.load_goal_state(chat_name)
     state["messages_since_goal_eval"] = (
         state.get("messages_since_goal_eval", 0) + 1
     )
@@ -167,19 +167,19 @@ def _maybe_generate_goals(
     LOGGER.log(
         "goal_state_check",
         {
-            "chat_id": chat_id,
+            "chat_name": chat_name,
             "current": state["messages_since_goal_eval"],
             "refresh_rate": refresh,
             "generate": state["messages_since_goal_eval"] >= refresh,
         },
     )
     if state["messages_since_goal_eval"] < refresh:
-        memory.save_goal_state(chat_id, state)
+        memory.save_goal_state(chat_name, state)
         return
 
     goal_limit = GENERATION_CONFIG.get("goal_limit", 3)
 
-    history = memory.load_history(chat_id)
+    history = memory.load_history(chat_name)
     user_text = "\n".join(m.get("content", "") for m in history)
 
     system_parts = [p for p in (global_prompt, character, setting) if p]
@@ -227,18 +227,18 @@ Do not include any explanation, commentary, or other text. If no goals are curre
 
     goals = _parse_goals_from_response(text)
     if not goals:
-        memory.save_goal_state(chat_id, state)
+        memory.save_goal_state(chat_name, state)
         return
 
     goals = _dedupe_new_goals(goals, state.get("goals", []))
     if not goals:
-        memory.save_goal_state(chat_id, state)
+        memory.save_goal_state(chat_name, state)
         return
 
     combined = state.get("goals", []) + goals
     state["goals"] = combined[:goal_limit]
     state["messages_since_goal_eval"] = 0
-    memory.save_goal_state(chat_id, state)
+    memory.save_goal_state(chat_name, state)
 
 
 # ---------------------------------------------------------------------------
@@ -256,7 +256,7 @@ def _finalize_chat(
         "chat_flow",
         {
             "function": "_finalize_chat",
-            "chat_id": call.chat_id,
+            "chat_name": call.chat_name,
             "reply": reply,
             "prompt": prompt,
             "message": call.message,
@@ -267,13 +267,13 @@ def _finalize_chat(
         },
     )
 
-    history = memory.load_history(call.chat_id)
+    history = memory.load_history(call.chat_name)
     history.append({"role": "assistant", "content": reply})
-    memory.save_history(call.chat_id, history)
+    memory.save_history(call.chat_name, history)
     enqueue_task(
         "goal_generation",
         _maybe_generate_goals,
-        call.chat_id,
+        call.chat_name,
         call.global_prompt,
         memory,
     )
@@ -284,7 +284,7 @@ def handle_chat(
     memory: MemoryManager = MEMORY_MANAGER,
     stream: bool = False,
     *,
-    current_chat_id: str | None = None,
+    current_chat_name: str | None = None,
     current_prompt: str | None = None,
 ):
     """Process ``call`` and return a model reply."""
@@ -293,16 +293,21 @@ def handle_chat(
         "chat_flow",
         {
             "function": "handle_chat",
-            "chat_id": current_chat_id or call.chat_id,
+            "chat_name": current_chat_name or call.chat_name,
             "message": call.message,
             "global_prompt": call.global_prompt,
             "call_type": call.call_type,
             "options": call.options,
             "stream": stream,
-            "current_chat_id": current_chat_id,
+            "current_chat_name": current_chat_name,
             "current_prompt": current_prompt,
             "memory_root": memory.root_dir,
         },
+    )
+
+    memory.update_paths(
+        chat_name=current_chat_name or call.chat_name,
+        prompt_name=current_prompt or call.global_prompt,
     )
 
     from .call_templates import standard_chat, logic_check
@@ -357,33 +362,33 @@ class ChatRunner:
         memory: MemoryManager = MEMORY_MANAGER,
     ) -> None:
         self.memory = memory
-        self.current_chat_id: str | None = None
+        self.current_chat_name: str | None = None
         self.current_prompt: str | None = None
 
     def process_user_message(
-        self, chat_id: str, message: str, stream: bool = False
+        self, chat_name: str, message: str, stream: bool = False
     ):
         LOGGER.log(
             "chat_flow",
             {
                 "function": "ChatRunner.process_user_message",
-                "chat_id": chat_id,
+                "chat_name": chat_name,
                 "message": message,
                 "stream": stream,
-                "current_chat_id": self.current_chat_id,
+                "current_chat_name": self.current_chat_name,
                 "current_prompt": self.current_prompt,
             },
         )
         call = CallData(
-            chat_id=chat_id, message=message, options={"stream": stream}
+            chat_name=chat_name, message=message, options={"stream": stream}
         )
         result = handle_chat(
             call,
             self.memory,
             stream=stream,
-            current_chat_id=self.current_chat_id,
+            current_chat_name=self.current_chat_name,
             current_prompt=self.current_prompt,
         )
-        self.current_chat_id = call.chat_id
+        self.current_chat_name = call.chat_name
         self.current_prompt = call.global_prompt or self.current_prompt
         return result

--- a/mythforge/call_templates/standard_chat.py
+++ b/mythforge/call_templates/standard_chat.py
@@ -23,7 +23,7 @@ def prepare_and_chat(call: "CallData"):
         "chat_flow",
         {
             "function": "prepare_and_chat",
-            "chat_id": call.chat_id,
+            "chat_name": call.chat_name,
             "message": call.message,
             "global_prompt": call.global_prompt,
             "call_type": call.call_type,

--- a/mythforge/memory.py
+++ b/mythforge/memory.py
@@ -62,11 +62,11 @@ class MemoryManager:
     # ------------------------------------------------------------------
     # Path helpers
     # ------------------------------------------------------------------
-    def _chat_file(self, chat_id: str, filename: str) -> str:
-        return os.path.join(self.chats_dir, chat_id, filename)
+    def _chat_file(self, chat_name: str, filename: str) -> str:
+        return os.path.join(self.chats_dir, chat_name, filename)
 
-    def _ensure_chat_dir(self, chat_id: str) -> str:
-        path = os.path.join(self.chats_dir, chat_id)
+    def _ensure_chat_dir(self, chat_name: str) -> str:
+        path = os.path.join(self.chats_dir, chat_name)
         os.makedirs(path, exist_ok=True)
         return path
 
@@ -74,8 +74,14 @@ class MemoryManager:
         safe = "".join(c if c.isalnum() or c in ("-", "_") else "_" for c in name)
         return os.path.join(self.prompts_dir, f"{safe}.json")
 
-    def _goals_path(self, chat_id: str) -> str:
-        return self._chat_file(chat_id, "goals.json")
+    def _goals_path(self, chat_name: str) -> str:
+        return self._chat_file(chat_name, "goals.json")
+
+    def get_chat_path(self, chat_name: str, filename: str) -> str:
+        """Return path to ``filename`` inside ``chat_name`` chat directory."""
+
+        self._ensure_chat_dir(chat_name)
+        return self._chat_file(chat_name, filename)
 
     # ------------------------------------------------------------------
     # Basic JSON file helpers
@@ -89,14 +95,14 @@ class MemoryManager:
     # ------------------------------------------------------------------
     # History helpers
     # ------------------------------------------------------------------
-    def load_history(self, chat_id: str) -> List[Dict[str, Any]]:
-        self.update_paths(chat_name=chat_id)
-        return list(self._read_json(self._chat_file(chat_id, "full.json")))
+    def load_history(self, chat_name: str) -> List[Dict[str, Any]]:
+        self.update_paths(chat_name=chat_name)
+        return list(self._read_json(self._chat_file(chat_name, "full.json")))
 
-    def save_history(self, chat_id: str, history: List[Dict[str, Any]]) -> None:
-        self._ensure_chat_dir(chat_id)
-        self.update_paths(chat_name=chat_id)
-        self._write_json(self._chat_file(chat_id, "full.json"), history)
+    def save_history(self, chat_name: str, history: List[Dict[str, Any]]) -> None:
+        self._ensure_chat_dir(chat_name)
+        self.update_paths(chat_name=chat_name)
+        self._write_json(self._chat_file(chat_name, "full.json"), history)
 
 
     def list_chats(self) -> List[str]:
@@ -107,8 +113,8 @@ class MemoryManager:
             if os.path.isdir(os.path.join(self.chats_dir, d))
         ]
 
-    def delete_chat(self, chat_id: str) -> None:
-        chat_dir = os.path.join(self.chats_dir, chat_id)
+    def delete_chat(self, chat_name: str) -> None:
+        chat_dir = os.path.join(self.chats_dir, chat_name)
         if os.path.isdir(chat_dir):
             for fname in os.listdir(chat_dir):
                 os.remove(os.path.join(chat_dir, fname))
@@ -123,8 +129,8 @@ class MemoryManager:
     # ------------------------------------------------------------------
     # Goal state helpers
     # ------------------------------------------------------------------
-    def load_goal_state(self, chat_id: str) -> Dict[str, Any]:
-        path = self._chat_file(chat_id, "goal_state.json")
+    def load_goal_state(self, chat_name: str) -> Dict[str, Any]:
+        path = self._chat_file(chat_name, "goal_state.json")
         if os.path.exists(path):
             data = self._read_json(path)
             if isinstance(data, dict):
@@ -135,22 +141,22 @@ class MemoryManager:
             "messages_since_goal_eval": 0,
         }
 
-    def save_goal_state(self, chat_id: str, state: Dict[str, Any]) -> None:
-        self._write_json(self._chat_file(chat_id, "goal_state.json"), state)
+    def save_goal_state(self, chat_name: str, state: Dict[str, Any]) -> None:
+        self._write_json(self._chat_file(chat_name, "goal_state.json"), state)
 
-    def disable_goals(self, chat_id: str) -> None:
-        path = self._goals_path(chat_id)
-        disabled = self._chat_file(chat_id, "goals_disabled.json")
+    def disable_goals(self, chat_name: str) -> None:
+        path = self._goals_path(chat_name)
+        disabled = self._chat_file(chat_name, "goals_disabled.json")
         if os.path.exists(path):
             os.rename(path, disabled)
-        self.load_goals(chat_id)
+        self.load_goals(chat_name)
 
-    def enable_goals(self, chat_id: str) -> None:
-        path = self._goals_path(chat_id)
-        disabled = self._chat_file(chat_id, "goals_disabled.json")
+    def enable_goals(self, chat_name: str) -> None:
+        path = self._goals_path(chat_name)
+        disabled = self._chat_file(chat_name, "goals_disabled.json")
         if os.path.exists(disabled):
             os.rename(disabled, path)
-        self.load_goals(chat_id)
+        self.load_goals(chat_name)
 
     # ------------------------------------------------------------------
     # Settings helpers

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -8,7 +8,7 @@ from mythforge import model
 
 
 def test_handle_chat_invokes_llm(monkeypatch):
-    call = CallData(chat_id="c1", message="hi", options={"stream": False})
+    call = CallData(chat_name="c1", message="hi", options={"stream": False})
     count = {"n": 0}
 
     def fake_invoke(self, prompt, opts=None):

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -20,7 +20,7 @@ def test_memory_history_basic(tmp_path):
 
 def test_prepare_call(monkeypatch):
     call = CallData(
-        chat_id="1", message="hi", global_prompt="Hello", options={}
+        chat_name="1", message="hi", global_prompt="Hello", options={}
     )
 
     invoked = {}
@@ -38,7 +38,7 @@ def test_prepare_call(monkeypatch):
 
 def test_global_prompt_usage(monkeypatch):
     call = CallData(
-        chat_id="1", message="hi", global_prompt="Custom", options={}
+        chat_name="1", message="hi", global_prompt="Custom", options={}
     )
 
     monkeypatch.setattr(

--- a/ui/MythForgeUI.html
+++ b/ui/MythForgeUI.html
@@ -335,14 +335,27 @@
         const basePath = window.location.pathname.replace(/\/[^/]*$/, '');
         const CONFIG = { apiUrl: window.location.origin + basePath };
 
-        function apiFetch(path, options){
+        function apiFetch(path, options={}){
             const base = CONFIG.apiUrl.replace(/\/$/, '');
             const rel = path.startsWith('/') ? path : '/' + path;
-            return fetch(base + rel, options);
+            const method = (options.method||'GET').toUpperCase();
+            if(method==='GET'){
+                const url = new URL(base+rel);
+                url.searchParams.set('chat_name', state.currentChatName);
+                url.searchParams.set('prompt_name', state.currentPrompt);
+                return fetch(url, options);
+            }
+            options.headers = options.headers||{'Content-Type':'application/json'};
+            let payload={};
+            try{ if(options.body) payload=JSON.parse(options.body); }catch{}
+            payload.chat_name = state.currentChatName;
+            payload.prompt_name = state.currentPrompt;
+            options.body = JSON.stringify(payload);
+            return fetch(base+rel, options);
         }
         const state = {
             chats: [],
-            currentChatId: '',
+            currentChatName: '',
             prompts: [],
             currentPrompt: '',
             settings: {
@@ -658,7 +671,7 @@
             promptTab.classList.remove('active');
             moreTab.classList.remove('active');
             fetchChatList().then(()=>{
-                if(state.currentChatId) loadChat(state.currentChatId);
+                if(state.currentChatName) loadChat(state.currentChatName);
             });
         }
 
@@ -682,7 +695,7 @@
             promptTab.classList.add('active');
             moreTab.classList.remove('active');
             refreshGlobalPromptList().then(()=>{
-                const last = localStorage.getItem('lastGlobalPrompt');
+                const last = localStorage.getItem('lastPromptName');
                 if(last) selectPrompt(last);
             });
         }
@@ -700,7 +713,7 @@
                 const div = document.createElement('div');
                 div.className = 'chat-history-item';
 
-                if(id === state.currentChatId) div.classList.add('active');
+                if(id === state.currentChatName) div.classList.add('active');
 
                 const nameSpan = document.createElement('span');
                 nameSpan.className = 'chat-name';
@@ -730,7 +743,7 @@
             const items = historyContainer.querySelectorAll('.chat-history-item');
             items.forEach(div=>{
                 const name = div.querySelector('.chat-name').textContent;
-                if(name === state.currentChatId){
+                if(name === state.currentChatName){
                     div.classList.add('active');
                 }else{
                     div.classList.remove('active');
@@ -743,19 +756,19 @@
                 const res = await apiFetch('/chats/');
                 const json = await res.json();
                 state.chats = json.chats.sort((a,b)=>a.localeCompare(b));
-                const last = localStorage.getItem('lastChatId');
+                const last = localStorage.getItem('lastChatName');
                 if(last && state.chats.includes(last)){
-                    state.currentChatId = last;
-                }else if(state.chats.length && !state.currentChatId){
-                    state.currentChatId = state.chats[0];
+                    state.currentChatName = last;
+                }else if(state.chats.length && !state.currentChatName){
+                    state.currentChatName = state.chats[0];
                 }
                 renderHistory();
             }catch(e){ console.error('Failed to fetch chats:', e); }
         }
 
         async function loadChat(id){
-            state.currentChatId = id;
-            localStorage.setItem('lastChatId', id);
+            state.currentChatName = id;
+            localStorage.setItem('lastChatName', id);
             updateActiveChat();
             chatContainer.innerHTML='';
             systemPrompt.textContent='';
@@ -766,9 +779,9 @@
                 const data = await res.json();
                 let msgs = data;
                 if(!Array.isArray(data)){
-                    if(data.chat_id){
-                        state.currentChatId = data.chat_id;
-                        localStorage.setItem('lastChatId', data.chat_id);
+                    if(data.chat_name){
+                        state.currentChatName = data.chat_name;
+                        localStorage.setItem('lastChatName', data.chat_name);
                         updateActiveChat();
                     }
                     msgs = data.history || [];
@@ -811,7 +824,7 @@
                 const res = await apiFetch('/prompts/?names_only=1');
                 const json = await res.json();
                 state.prompts = json.prompts.sort((a,b)=>a.localeCompare(b));
-                const last = localStorage.getItem('lastGlobalPrompt');
+                const last = localStorage.getItem('lastPromptName');
                 if(last && state.prompts.includes(last)){
                     await selectPrompt(last);
                 }else{
@@ -865,7 +878,7 @@
                 state.prompts = state.prompts.filter(p=>p!==editingPromptName);
                 if(state.currentPrompt===editingPromptName){
                     state.currentPrompt = '';
-                    localStorage.setItem('lastGlobalPrompt','');
+                    localStorage.setItem('lastPromptName','');
                 }
                 renderPromptList();
             }
@@ -928,26 +941,26 @@
                     return;
                 }
                 const data = await res.json().catch(()=>({}));
-                name = data.chat_id || name;
+                name = data.chat_name || name;
             }catch(e){ console.error('Failed to create chat:', e); return; }
             await fetchChatList();
-            state.currentChatId = name;
-            localStorage.setItem('lastChatId', name);
+            state.currentChatName = name;
+            localStorage.setItem('lastChatName', name);
             renderHistory();
             chatContainer.innerHTML = '';
             systemPrompt.textContent = '';
             systemToggle.style.display = 'none';
         }
 
-        async function deleteChat(chatId = state.currentChatId){
+        async function deleteChat(chatId = state.currentChatName){
             if(!chatId) return alert('Nothing to delete.');
             confirmDialog('Are you sure you want to delete this chat?', async ()=>{
                 try{
                 const res = await apiFetch(`/chats/${encodeURIComponent(chatId)}`, {method:'DELETE'});
                 if(!res.ok){ if(res.status===404) throw new Error('Chat not found on server.'); else throw new Error('Unknown server error.'); }
                 await fetchChatList();
-                state.currentChatId = state.chats.length ? state.chats[0] : '';
-                localStorage.setItem('lastChatId', state.currentChatId);
+                state.currentChatName = state.chats.length ? state.chats[0] : '';
+                localStorage.setItem('lastChatName', state.currentChatName);
                 renderHistory();
                 chatContainer.innerHTML = '';
                 systemPrompt.textContent = '';
@@ -989,8 +1002,8 @@
                             }
                         }catch(e){ console.error('Rename failed:', e); alert('Failed to rename chat: '+e.message); return; }
                         await fetchChatList();
-                        state.currentChatId = trimmed;
-                        localStorage.setItem('lastChatId', trimmed);
+                        state.currentChatName = trimmed;
+                        localStorage.setItem('lastChatName', trimmed);
                         renderHistory();
                     }
                     if(document.getElementById('goals-context').style.display!=='none'){
@@ -1023,7 +1036,7 @@
 
         async function selectPrompt(name){
             state.currentPrompt = name;
-            localStorage.setItem('lastGlobalPrompt', name);
+            localStorage.setItem('lastPromptName', name);
             renderPromptList();
             try{
                 await apiFetch('/prompts/select', {
@@ -1067,13 +1080,13 @@
         async function editMessage(index, current){
             promptTextarea('Edit message:', current, async (text)=>{
                 try{
-                    const res = await apiFetch(`/chats/${encodeURIComponent(state.currentChatId)}/history/${index}`, {
+                    const res = await apiFetch(`/chats/${encodeURIComponent(state.currentChatName)}/history/${index}`, {
                         method:'PUT',
                         headers:{'Content-Type':'application/json'},
                         body: JSON.stringify({content:text})
                     });
                     if(!res.ok){ const j=await res.json(); throw new Error(j.detail||'Server error'); }
-                    await loadChat(state.currentChatId);
+                    await loadChat(state.currentChatName);
                 }catch(e){ alert('Failed to edit: '+e.message); }
             });
         }
@@ -1081,9 +1094,9 @@
         async function deleteMessage(index){
             confirmDialog('Delete this message?', async ()=>{
                 try{
-                    const res = await apiFetch(`/chats/${encodeURIComponent(state.currentChatId)}/history/${index}`, {method:'DELETE'});
+                    const res = await apiFetch(`/chats/${encodeURIComponent(state.currentChatName)}/history/${index}`, {method:'DELETE'});
                     if(!res.ok){ const j=await res.json(); throw new Error(j.detail||'Server error'); }
-                    await loadChat(state.currentChatId);
+                    await loadChat(state.currentChatName);
                 }catch(e){ alert('Failed to delete: '+e.message); }
             });
         }
@@ -1172,7 +1185,7 @@
         async function sendMessage(allowEmpty=false){
             const text = userInput.value.trim();
             if(state.isGenerating) return;
-            if(!state.currentChatId){
+            if(!state.currentChatName){
                 await startNewChat();
             }
             if(text==='' && !allowEmpty) return;
@@ -1185,10 +1198,10 @@
                 state.isProcessing=true;
                 updateBusyUI();
                 try{
-                    const res = await apiFetch(`/chats/${encodeURIComponent(state.currentChatId)}/cli`, {
+                    const res = await apiFetch(`/chats/${encodeURIComponent(state.currentChatName)}/cli`, {
                         method:'POST',
                         headers:{'Content-Type':'application/json'},
-                        body: JSON.stringify({chat_id: state.currentChatId, message: text})
+                        body: JSON.stringify({message: text})
                     });
                     const data = await res.json();
                     appendMessageToUI('assistant', data.detail || '');
@@ -1209,13 +1222,10 @@
             updateBusyUI();
             abortController = new AbortController();
             try{
-                const response = await apiFetch(`/chats/${encodeURIComponent(state.currentChatId)}/message`, {
+                const response = await apiFetch(`/chats/${encodeURIComponent(state.currentChatName)}/message`, {
                     method:'POST',
                     headers:{'Content-Type':'application/json'},
-                    body: JSON.stringify({
-                        chat_id: state.currentChatId,
-                        message: text
-                    }),
+                    body: JSON.stringify({message: text}),
                     signal: abortController.signal
                 });
                 if(!response.ok) throw new Error(`Server returned ${response.status}`);
@@ -1299,7 +1309,7 @@
         async function sendMessageNoGen(){
             const text = userInput.value.trim();
             if(text==='' || state.isGenerating) return;
-            if(!state.currentChatId){
+            if(!state.currentChatName){
                 await startNewChat();
             }
             userInput.value=''; autoResize();
@@ -1309,7 +1319,7 @@
                 await apiFetch('/chats/message', {
                     method:'POST',
                     headers:{'Content-Type':'application/json'},
-                    body: JSON.stringify({chat_id: state.currentChatId, message: text})
+                    body: JSON.stringify({message: text})
                 });
             }catch(err){
                 console.error('Send only failed:', err);
@@ -1367,7 +1377,7 @@
             showChatTab();
             await refreshGlobalPromptList();
             await fetchChatList();
-            if(state.currentChatId) await loadChat(state.currentChatId);
+            if(state.currentChatName) await loadChat(state.currentChatName);
             await loadServerSettings();
             autoResize();
             updateBusyUI();


### PR DESCRIPTION
## Summary
- inject chat and prompt context through MemoryManager
- rename ChatRequest fields and update routing for chat_name
- add automatic context injection in the UI
- adjust tests for new CallData interface

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_684e9453dc88832bae74cfa8fd6bd9ac