### PR TITLE
Fix core chat route and JSON handling

### DIFF
--- a/mythforge/call_core.py
+++ b/mythforge/call_core.py
@@ -125,12 +125,12 @@ Do not include any explanation, commentary, or other text. If no goals are curre
         },
     )
 
-    from .call_templates import goal_generation
+    from .call_templates import generate_goals
 
-    text = goal_generation.generate_goals(
+    text = generate_goals.generate_goals(
         system_text,
         user_text,
-        {**goal_generation.MODEL_LAUNCH_OVERRIDE},
+        {**generate_goals.MODEL_LAUNCH_OVERRIDE},
     )
 
     parsed = ResponseParser().load(text).parse()

--- a/mythforge/invoker.py
+++ b/mythforge/invoker.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 """LLM invocation utilities."""
 
 from typing import Any, Dict
+import os
 
 from .logger import LOGGER
 
@@ -40,7 +41,11 @@ class LLMInvoker:
                 "options": opts,
             },
         )
-        return call_llm("", prompt, **opts)
+        model_name = (
+            self.config.get("model_name")
+            or os.environ.get("MODEL_NAME", "gpt-4")
+        )
+        return call_llm(model_name, prompt, **opts)
 
 
 LLM_INVOKER = LLMInvoker()

--- a/mythforge/memory.py
+++ b/mythforge/memory.py
@@ -24,6 +24,11 @@ def _load_json(path: str) -> list[Any] | dict[str, Any] | list:
                 LOGGER = None
             if LOGGER is not None:
                 LOGGER.log_error(e)
+            try:
+                os.rename(path, path + ".corrupt")
+            except Exception as exc:  # pragma: no cover - best effort
+                if LOGGER is not None:
+                    LOGGER.log_error(exc)
     return []
 
 
@@ -31,8 +36,10 @@ def _save_json(path: str, data: Any) -> None:
     """Write ``data`` as JSON to ``path``."""
 
     os.makedirs(os.path.dirname(path), exist_ok=True)
-    with open(path, "w", encoding="utf-8") as f:
+    tmp = f"{path}.tmp"
+    with open(tmp, "w", encoding="utf-8") as f:
         json.dump(data, f, indent=2, ensure_ascii=False)
+    os.replace(tmp, path)
 
 
 @dataclass


### PR DESCRIPTION
## Summary
- hook up call_core.handle_chat via new `/chats/{chat_name}/message` route
- back up corrupt JSON and use atomic writes
- correct goal generation import
- provide default model name when invoking

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_685055ceb2f0832ba7c5822dc65ae8cc