### PR TITLE
Load model on startup

### DIFF
--- a/mythforge/main.py
+++ b/mythforge/main.py
@@ -30,9 +30,7 @@ init_memory(memory_manager)
 async def startup_event() -> None:
     """Initialize directories and default prompts on startup."""
     try:
-        call = CallData(
-            chat_name="startup", message="", options={"stream": False}
-        )
+        model._get_llama()
     except Exception as exc:  # pragma: no cover - best effort
         LOGGER.log_error(exc)
 


### PR DESCRIPTION
## Summary
- preload the primary model during app startup

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_685058e343bc832b99efe3ed48ca5d6f