### PR TITLE
Fix n_gpu_layers param issue

### DIFF
--- a/mythforge/model.py
+++ b/mythforge/model.py
@@ -109,6 +109,7 @@ def call_llm(system_prompt: str, user_prompt: str, **overrides):
 
     background = params.pop("background", False)
     stream = params.pop("stream", True)
+    params.pop("n_gpu_layers", None)
 
     llm = _get_llama(background)
     prompt = f"{system_prompt}\n{user_prompt}".strip()


### PR DESCRIPTION
## Summary
- remove `n_gpu_layers` from parameters passed to `create_completion`

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_68505a2be2ac832b87e7b62b6d76970a