### PR TITLE
Fix llama completion arg

### DIFF
--- a/mythforge/model.py
+++ b/mythforge/model.py
@@ -107,6 +107,9 @@ def call_llm(system_prompt: str, user_prompt: str, **overrides):
     params = MODEL_LAUNCH_ARGS.copy()
     params.update(overrides)
 
+    if "temp" in params:
+        params["temperature"] = params.pop("temp")
+
     background = params.pop("background", False)
     stream = params.pop("stream", True)
     params.pop("n_gpu_layers", None)


### PR DESCRIPTION
## Summary
- map `temp` to `temperature` before calling Llama.create_completion

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68505b3ad774832bb2f09778e66580f2