### PR TITLE
Fix prompt handling and unify streaming parser

### DIFF
--- a/mythforge/call_core.py
+++ b/mythforge/call_core.py
@@ -205,21 +205,22 @@ def handle_chat(
 
     memory.update_paths(
         chat_name=current_chat_name or call.chat_name,
-        prompt_name=current_prompt or call.global_prompt,
+        prompt_name=current_prompt or memory.global_prompt_name,
     )
 
     from .call_templates import standard_chat, logic_check
 
     call.options = call.options or {"stream": stream}
 
-    if call.call_type == "logic_check":
-        processed = logic_check.logic_check(
-            call.global_prompt,
-            call.message,
-            call.options,
-        )
-    else:
-        processed = standard_chat.standard_chat(call)
+    call_map = {
+        "logic_check": lambda c: logic_check.logic_check(
+            c.global_prompt, c.message, c.options
+        ),
+        "standard_chat": lambda c: standard_chat.standard_chat(c),
+    }
+
+    handler = call_map.get(call.call_type, call_map["standard_chat"])
+    processed = handler(call)
 
     if stream:
 
@@ -239,9 +240,7 @@ def handle_chat(
 
         return StreamingResponse(_generate(), media_type="text/plain")
 
-    assistant_reply = (
-        processed if isinstance(processed, str) else str(processed)
-    )
+    assistant_reply = "".join(list(processed)).strip()
     _finalize_chat(
         assistant_reply,
         call,

--- a/mythforge/call_templates/generate_goals.py
+++ b/mythforge/call_templates/generate_goals.py
@@ -17,21 +17,11 @@ MODEL_LAUNCH_OVERRIDE: Dict[str, Any] = {
 }
 
 
-def generate_goals(global_prompt: str, message: str, options: Dict[str, Any]):
+def generate_goals(
+    global_prompt: str, message: str, options: Dict[str, Any]
+) -> Iterator[str]:
     """Run the goal-generation template and return parsed output."""
 
     prepared = PromptPreparer().prepare(global_prompt, message)
     raw = LLMInvoker().invoke(prepared, options)
-    parsed = ResponseParser().load(raw).parse()
-    if isinstance(parsed, Iterator):
-        try:
-            first = next(parsed)
-        except StopIteration as exc:  # pragma: no cover - best effort
-            return str(exc.value)
-
-        def _chain() -> Iterator[str]:
-            yield first
-            yield from parsed
-
-        return _chain()
-    return parsed
+    return ResponseParser().load(raw).parse()

--- a/mythforge/call_templates/logic_check.py
+++ b/mythforge/call_templates/logic_check.py
@@ -18,21 +18,11 @@ MODEL_LAUNCH_OVERRIDE: Dict[str, Any] = {
 
 # CallType helpers -----------------------------------------------------------
 
-def logic_check(global_prompt: str, message: str, options: Dict[str, Any]):
+def logic_check(
+    global_prompt: str, message: str, options: Dict[str, Any]
+) -> Iterator[str]:
     """Send ``message`` through a logic-checking prompt."""
 
     prepared = PromptPreparer().prepare(global_prompt, message)
     raw = LLMInvoker().invoke(prepared, options)
-    parsed = ResponseParser().load(raw).parse()
-    if isinstance(parsed, Iterator):
-        try:
-            first = next(parsed)
-        except StopIteration as exc:  # pragma: no cover - best effort
-            return str(exc.value)
-
-        def _chain() -> Iterator[str]:
-            yield first
-            yield from parsed
-
-        return _chain()
-    return parsed
+    return ResponseParser().load(raw).parse()

--- a/mythforge/call_templates/standard_chat.py
+++ b/mythforge/call_templates/standard_chat.py
@@ -16,7 +16,7 @@ MODEL_LAUNCH_OVERRIDE: Dict[str, Any] = {
     "stream": True,
 }
 
-def standard_chat(call: "CallData"):
+def standard_chat(call: "CallData") -> Iterator[str]:
     """Apply the standard template, invoke the model and return a reply."""
 
     LOGGER.log(
@@ -33,17 +33,5 @@ def standard_chat(call: "CallData"):
 
     prepared = PromptPreparer().prepare(call.global_prompt, call.message)
     raw = LLMInvoker().invoke(prepared, call.options)
-    parsed = ResponseParser().load(raw).parse()
-    if isinstance(parsed, Iterator):
-        try:
-            first = next(parsed)
-        except StopIteration as exc:  # pragma: no cover - best effort
-            return str(exc.value)
-
-        def _chain() -> Iterator[str]:
-            yield first
-            yield from parsed
-
-        return _chain()
-    return parsed
+    return ResponseParser().load(raw).parse()
 

--- a/mythforge/invoker.py
+++ b/mythforge/invoker.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 """LLM invocation utilities."""
 
 from typing import Any, Dict
-import os
 
 from .logger import LOGGER
 
@@ -41,11 +40,7 @@ class LLMInvoker:
                 "options": opts,
             },
         )
-        model_name = (
-            self.config.get("model_name")
-            or os.environ.get("MODEL_NAME", "gpt-4")
-        )
-        return call_llm(model_name, prompt, **opts)
+        return call_llm(prompt, **opts)
 
 
 LLM_INVOKER = LLMInvoker()

--- a/mythforge/model.py
+++ b/mythforge/model.py
@@ -99,8 +99,8 @@ MODEL_LAUNCH_ARGS: Dict[str, object] = {
 }
 
 
-def call_llm(system_prompt: str, user_prompt: str, **overrides):
-    """Route a prompt through ``llama_cpp`` and return the response."""
+def call_llm(prompt: str, **overrides):
+    """Route ``prompt`` through ``llama_cpp`` and return the response."""
 
     params = MODEL_LAUNCH_ARGS.copy()
     params.update(overrides)
@@ -110,7 +110,6 @@ def call_llm(system_prompt: str, user_prompt: str, **overrides):
     params.pop("n_gpu_layers", None)
 
     llm = _get_llama(background)
-    prompt = f"{system_prompt}\n{user_prompt}".strip()
 
     if stream:
 

--- a/mythforge/prompt_preparer.py
+++ b/mythforge/prompt_preparer.py
@@ -11,20 +11,28 @@ class PromptPreparer:
     """Combine system and user text into a single prompt string."""
 
     def __init__(self) -> None:
-        """Load template data for prompt assembly."""
+        """No template state is stored by default."""
 
         self.template: str = ""
 
-    def load_template(self, name: str) -> str:
-        """Read the template named ``name`` from storage."""
+    def prepare(
+        self,
+        system_text: str | None = None,
+        user_text: str = "",
+        *,
+        name: str | None = None,
+    ) -> str:
+        """Return a full prompt for ``system_text`` and ``user_text``.
 
-        from .memory import MEMORY_MANAGER
+        If ``name`` is provided, ``system_text`` will be loaded from the
+        :class:`MemoryManager` using that prompt name.
+        """
 
-        self.template = MEMORY_MANAGER.get_global_prompt(name)
-        return self.template
+        if name is not None:
+            from .memory import MEMORY_MANAGER
 
-    def prepare(self, system_text: str, user_text: str) -> str:
-        """Inject texts into ``self.template`` and return the final prompt."""
+            system_text = MEMORY_MANAGER.get_global_prompt(name)
+        system_text = system_text or ""
 
         LOGGER.log(
             "chat_flow",

--- a/mythforge/response_parser.py
+++ b/mythforge/response_parser.py
@@ -31,8 +31,8 @@ class ResponseParser:
         self.raw = raw
         return self
 
-    def parse(self) -> Any:
-        """Extract structured data from ``self.raw``."""
+    def parse(self) -> Iterator[str]:
+        """Yield text fragments extracted from ``self.raw``."""
 
         LOGGER.log(
             "chat_flow",
@@ -54,9 +54,16 @@ class ResponseParser:
                         yield str(chunk)
 
             return _iter()
+
         if isinstance(self.raw, dict) and "text" in self.raw:
-            return str(self.raw["text"])
-        return str(self.raw)
+            text = str(self.raw["text"])
+        else:
+            text = str(self.raw)
+
+        def _single() -> Iterator[str]:
+            yield text
+
+        return _single()
 
 def _parse_goals_from_response(text: str) -> List[Dict[str, Any]]:
     """Extract individual goal entries from ``text``."""


### PR DESCRIPTION
## Summary
- merge `PromptPreparer.load_template` with `prepare`
- make `ResponseParser.parse` always yield an iterator
- remove prompt concatenation in `call_llm`
- adjust `LLMInvoker` and templates for the new API
- clean up `handle_chat` dispatch and streaming logic

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_685060c9b3f4832ba8f290d4489bfa4f