### PR TITLE
Remove duplicate path update

### DIFF
--- a/mythforge/call_core.py
+++ b/mythforge/call_core.py
@@ -203,10 +203,6 @@ def handle_chat(
         },
     )
 
-    memory.update_paths(
-        chat_name=current_chat_name or call.chat_name,
-        prompt_name=current_prompt or call.global_prompt,
-    )
 
     from .call_templates import standard_chat, logic_check
 


### PR DESCRIPTION
## Summary
- avoid calling `update_paths` in `handle_chat`

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6850612340ac832bae79d6e6b2ee5a70