### PR TITLE
Add default max tokens

### DIFF
--- a/mythforge/model.py
+++ b/mythforge/model.py
@@ -95,6 +95,7 @@ MODEL_LAUNCH_ARGS: Dict[str, object] = {
     "background": False,
     "stream": True,
     "n_gpu_layers": DEFAULT_N_GPU_LAYERS,
+    "max_tokens": DEFAULT_MAX_TOKENS,
     **GENERATION_CONFIG,
 }
 


### PR DESCRIPTION
## Summary
- include `max_tokens` in default model launch arguments to avoid premature text cutoffs

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_6850646c1d10832b9b46dd054d50163e