### PR TITLE
Remove chat_name from requests

### DIFF
--- a/mythforge/main.py
+++ b/mythforge/main.py
@@ -55,7 +55,6 @@ def get_memory_manager() -> MemoryManager:
 class ChatRequest(BaseModel):
     """Request model for chat-related endpoints."""
 
-    chat_name: str
     message: str
     prompt_name: str | None = None
 

--- a/ui/script.js
+++ b/ui/script.js
@@ -15,7 +15,6 @@ return fetch(url, options);
     options.headers = options.headers||{'Content-Type':'application/json'};
     let payload={};
     try{ if(options.body) payload=JSON.parse(options.body); }catch{}
-    payload.chat_name = state.currentChatName;
     payload.prompt_name = state.currentPrompt;
     options.body = JSON.stringify(payload);
     return fetch(base+rel, options);


### PR DESCRIPTION
## Summary
- drop `chat_name` from `ChatRequest`
- stop sending `chat_name` in POST bodies

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68506733c8e8832ba3e7b5960707c59b