### PR TITLE
Add unified chat send endpoint

### DIFF
--- a/ui/script.js
+++ b/ui/script.js
@@ -15,6 +15,7 @@ return fetch(url, options);
     options.headers = options.headers||{'Content-Type':'application/json'};
     let payload={};
     try{ if(options.body) payload=JSON.parse(options.body); }catch{}
+    payload.chat_name = state.currentChatName;
     payload.prompt_name = state.currentPrompt;
     options.body = JSON.stringify(payload);
     return fetch(base+rel, options);
@@ -891,7 +892,7 @@ return;
     updateBusyUI();
     abortController = new AbortController();
     try{
-const response = await apiFetch(`/chats/${encodeURIComponent(state.currentChatName)}/message`, {
+const response = await apiFetch('/chat/send', {
     method:'POST',
     headers:{'Content-Type':'application/json'},
     body: JSON.stringify({message: text}),


### PR DESCRIPTION
## Summary
- allow ChatRequest to include `chat_name`
- add `/chat/send` route using JSON body for ids
- update existing message append endpoint
- send `chat_name` in UI fetches and hit new endpoint

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_685069f8fd58832ba186254b8ba89c8b