### PR TITLE
Refactor chat send flow

### DIFF
--- a/mythforge/call_templates/standard_chat.py
+++ b/mythforge/call_templates/standard_chat.py
@@ -16,22 +16,27 @@ MODEL_LAUNCH_OVERRIDE: Dict[str, Any] = {
     "stream": True,
 }
 
-def standard_chat(call: "CallData") -> Iterator[str]:
+def standard_chat(
+    chat_name: str,
+    message: str,
+    global_prompt: str,
+    options: Dict[str, Any],
+) -> Iterator[str]:
     """Apply the standard template, invoke the model and return a reply."""
 
     LOGGER.log(
         "chat_flow",
         {
             "function": "prepare_and_chat",
-            "chat_name": call.chat_name,
-            "message": call.message,
-            "global_prompt": call.global_prompt,
-            "call_type": call.call_type,
-            "options": call.options,
+            "chat_name": chat_name,
+            "message": message,
+            "global_prompt": global_prompt,
+            "call_type": "standard_chat",
+            "options": options,
         },
     )
 
-    prepared = PromptPreparer().prepare(call.global_prompt, call.message)
-    raw = LLMInvoker().invoke(prepared, call.options)
+    prepared = PromptPreparer().prepare(global_prompt, message)
+    raw = LLMInvoker().invoke(prepared, options)
     return ResponseParser().load(raw).parse()
 

--- a/ui/script.js
+++ b/ui/script.js
@@ -17,6 +17,7 @@ return fetch(url, options);
     try{ if(options.body) payload=JSON.parse(options.body); }catch{}
     payload.chat_name = state.currentChatName;
     payload.prompt_name = state.currentPrompt;
+    payload.global_prompt = state.currentPromptText || '';
     options.body = JSON.stringify(payload);
     return fetch(base+rel, options);
 }
@@ -25,6 +26,7 @@ const state = {
     currentChatName: '',
     prompts: [],
     currentPrompt: '',
+    currentPromptText: '',
     settings: {
 userName: 'You',
 botName: 'Bot',
@@ -439,6 +441,7 @@ async function loadChat(id){
     updateActiveChat();
     chatContainer.innerHTML='';
     systemPrompt.textContent='';
+    state.currentPromptText='';
     systemToggle.style.display='none';
     try{
 const res = await apiFetch(`/chats/${encodeURIComponent(id)}/history`);
@@ -619,6 +622,7 @@ name = data.chat_name || name;
     renderHistory();
     chatContainer.innerHTML = '';
     systemPrompt.textContent = '';
+    state.currentPromptText = '';
     systemToggle.style.display = 'none';
 }
 
@@ -633,8 +637,9 @@ state.currentChatName = state.chats.length ? state.chats[0] : '';
 localStorage.setItem('lastChatName', state.currentChatName);
 renderHistory();
 chatContainer.innerHTML = '';
-systemPrompt.textContent = '';
-systemToggle.style.display = 'none';
+    systemPrompt.textContent = '';
+    state.currentPromptText = '';
+    systemToggle.style.display = 'none';
 showChatTab();
 }catch(err){ console.error('Failed to delete chat:', err); alert('Error deleting chat: '+err.message); }
     });
@@ -932,6 +937,7 @@ while(true){
             try{
                 const meta = JSON.parse(metaStr);
                 systemPrompt.textContent = meta.prompt || '';
+                state.currentPromptText = meta.prompt || '';
                 systemToggle.style.display = meta.prompt ? 'block' : 'none';
             }catch{}
             gotMeta = true;


### PR DESCRIPTION
## Summary
- remove `CallData` usage and update core handlers accordingly
- add `SendChatRequest` model with `global_prompt`
- pass full prompt from UI when sending a chat message

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68506d04ed40832b9d06d6575173c540