### PR TITLE
Rename current_prompt to current_global_prompt

### DIFF
--- a/mythforge/call_core.py
+++ b/mythforge/call_core.py
@@ -180,7 +180,7 @@ def handle_chat(
     stream: bool = False,
     *,
     current_chat_name: str | None = None,
-    current_prompt: str | None = None,
+    current_global_prompt: str | None = None,
 ):
     """Orchestrate a full chat cycle and persist the result."""
 
@@ -195,7 +195,7 @@ def handle_chat(
             "options": options,
             "stream": stream,
             "current_chat_name": current_chat_name,
-            "current_prompt": current_prompt,
+            "current_global_prompt": current_global_prompt,
             "memory_root": memory.root_dir,
         },
     )
@@ -219,7 +219,7 @@ def handle_chat(
     if stream:
 
         def _generate():
-            meta = {"prompt": current_prompt or global_prompt}
+            meta = {"prompt": current_global_prompt or global_prompt}
             yield json.dumps(meta, ensure_ascii=False) + "\n"
 
             parts: list[str] = []
@@ -236,7 +236,7 @@ def handle_chat(
                 call_type,
                 options,
                 memory,
-                prompt=current_prompt,
+                prompt=current_global_prompt,
             )
 
         return StreamingResponse(_generate(), media_type="text/plain")
@@ -250,7 +250,7 @@ def handle_chat(
         call_type,
         options,
         memory,
-        prompt=current_prompt,
+        prompt=current_global_prompt,
     )
 
     return {"detail": assistant_reply}

--- a/mythforge/main.py
+++ b/mythforge/main.py
@@ -436,7 +436,7 @@ def chat_message(chat_name: str, req: ChatRequest):
         memory=memory_manager,
         stream=True,
         current_chat_name=chat_name,
-        current_prompt=req.global_prompt_name,
+        current_global_prompt=req.global_prompt_name,
     )
 
 
@@ -460,7 +460,7 @@ def send_chat(req: SendChatRequest):
         memory=memory_manager,
         stream=True,
         current_chat_name=memory_manager.chat_name,
-        current_prompt=req.global_prompt_name,
+        current_global_prompt=req.global_prompt_name,
     )
 
 

--- a/mythforge/memory.py
+++ b/mythforge/memory.py
@@ -389,7 +389,7 @@ MEMORY = MEMORY_MANAGER
 
 def set_global_prompt(global_prompt: str) -> None:
     """Convenience alias for :meth:`MemoryManager.set_global_prompt`."""
-    MEMORY_MANAGER.set_global_prompt("current_prompt", global_prompt)
+    MEMORY_MANAGER.set_global_prompt("current_global_prompt", global_prompt)
 
 
 def initialize(manager: MemoryManager = MEMORY_MANAGER) -> None:


### PR DESCRIPTION
## Summary
- update call_core handle_chat to use `current_global_prompt`
- rename parameter uses in API endpoints
- change MemoryManager alias to set `current_global_prompt`

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68507d184c9c832b8d4b9fdc6924872a