### PR TITLE
Replace history with chat_history

### DIFF
--- a/mythforge/call_core.py
+++ b/mythforge/call_core.py
@@ -15,8 +15,6 @@ from .memory import MemoryManager, MEMORY_MANAGER
 from .logger import LOGGER
 
 
-
-
 # ---------------------------------------------------------------------------
 # Text helpers
 # ---------------------------------------------------------------------------
@@ -56,9 +54,7 @@ def _maybe_generate_goals(
     setting = goals.setting
 
     state = memory.load_goal_state(chat_name)
-    state["messages_since_goal_eval"] = (
-        state.get("messages_since_goal_eval", 0) + 1
-    )
+    state["messages_since_goal_eval"] = state.get("messages_since_goal_eval", 0) + 1
 
     refresh = GENERATION_CONFIG.get("goal_refresh_rate", 1)
     LOGGER.log(
@@ -76,8 +72,8 @@ def _maybe_generate_goals(
 
     goal_limit = GENERATION_CONFIG.get("goal_limit", 3)
 
-    history = memory.load_history(chat_name)
-    user_text = "\n".join(m.get("content", "") for m in history)
+    chat_history = memory.load_chat_history(chat_name)
+    user_text = "\n".join(m.get("content", "") for m in chat_history)
 
     system_parts = [p for p in (global_prompt, character, setting) if p]
 
@@ -164,9 +160,9 @@ def _finalize_chat(
         },
     )
 
-    history = memory.load_history(chat_name)
-    history.append({"role": "assistant", "content": reply})
-    memory.save_history(chat_name, history)
+    chat_history = memory.load_chat_history(chat_name)
+    chat_history.append({"role": "assistant", "content": reply})
+    memory.save_chat_history(chat_name, chat_history)
     _maybe_generate_goals(chat_name, global_prompt, memory)
 
 
@@ -205,9 +201,7 @@ def handle_chat(
     options = options or {"stream": stream}
 
     call_map = {
-        "logic_check": lambda: logic_check.logic_check(
-            global_prompt, message, options
-        ),
+        "logic_check": lambda: logic_check.logic_check(global_prompt, message, options),
         "standard_chat": lambda: standard_chat.standard_chat(
             chat_name, message, global_prompt, options
         ),

--- a/mythforge/main.py
+++ b/mythforge/main.py
@@ -73,9 +73,13 @@ class SendChatRequest(ChatRequest):
 
 
 @global_prompt_router.get("/")
-def list_prompts(names_only: int = 0, chat_name: str = "", global_prompt_name: str = ""):
+def list_prompts(
+    names_only: int = 0, chat_name: str = "", global_prompt_name: str = ""
+):
     """Return all stored prompt entries or just their names."""
-    memory_manager.update_paths(chat_name=chat_name, global_prompt_name=global_prompt_name)
+    memory_manager.update_paths(
+        chat_name=chat_name, global_prompt_name=global_prompt_name
+    )
     if names_only:
         return {"prompts": memory_manager.list_global_prompt_names()}
     return {"prompts": memory_manager.load_global_prompts()}
@@ -84,7 +88,9 @@ def list_prompts(names_only: int = 0, chat_name: str = "", global_prompt_name: s
 @global_prompt_router.get("/{name}")
 def get_prompt(name: str, chat_name: str = "", global_prompt_name: str = ""):
     """Fetch the full content for ``name``."""
-    memory_manager.update_paths(chat_name=chat_name, global_prompt_name=global_prompt_name)
+    memory_manager.update_paths(
+        chat_name=chat_name, global_prompt_name=global_prompt_name
+    )
     content = memory_manager.get_global_prompt(name)
     if not content:
         raise HTTPException(status_code=404, detail="Prompt not found")
@@ -92,9 +98,13 @@ def get_prompt(name: str, chat_name: str = "", global_prompt_name: str = ""):
 
 
 @global_prompt_router.post("/")
-def create_prompt(item: Dict[str, str], chat_name: str = "", global_prompt_name: str = ""):
+def create_prompt(
+    item: Dict[str, str], chat_name: str = "", global_prompt_name: str = ""
+):
     """Create a new prompt file from ``item``."""
-    memory_manager.update_paths(chat_name=chat_name, global_prompt_name=global_prompt_name)
+    memory_manager.update_paths(
+        chat_name=chat_name, global_prompt_name=global_prompt_name
+    )
     memory_manager.set_global_prompt(item["name"], item.get("content", ""))
     return {"detail": "Created"}
 
@@ -104,7 +114,9 @@ def update_prompt(
     name: str, item: Dict[str, str], chat_name: str = "", global_prompt_name: str = ""
 ):
     """Overwrite an existing prompt with new content."""
-    memory_manager.update_paths(chat_name=chat_name, global_prompt_name=global_prompt_name)
+    memory_manager.update_paths(
+        chat_name=chat_name, global_prompt_name=global_prompt_name
+    )
     if item.get("name") != name:
         raise HTTPException(status_code=400, detail="Name mismatch")
     memory_manager.set_global_prompt(name, item.get("content", ""))
@@ -116,7 +128,9 @@ def rename_prompt(
     name: str, data: Dict[str, str], chat_name: str = "", global_prompt_name: str = ""
 ):
     """Rename a stored prompt without changing its content."""
-    memory_manager.update_paths(chat_name=chat_name, global_prompt_name=global_prompt_name)
+    memory_manager.update_paths(
+        chat_name=chat_name, global_prompt_name=global_prompt_name
+    )
     new_name = data.get("new_name", "").strip()
     if not new_name:
         raise HTTPException(status_code=400, detail="New name required")
@@ -136,15 +150,21 @@ def rename_prompt(
 @global_prompt_router.delete("/{name}")
 def remove_prompt(name: str, chat_name: str = "", global_prompt_name: str = ""):
     """Delete the prompt identified by ``name``."""
-    memory_manager.update_paths(chat_name=chat_name, global_prompt_name=global_prompt_name)
+    memory_manager.update_paths(
+        chat_name=chat_name, global_prompt_name=global_prompt_name
+    )
     memory_manager.delete_global_prompt(name)
     memory_manager.update_paths(global_prompt_name="")
     return {"detail": f"Deleted prompt '{name}'"}
 
 
 @global_prompt_router.post("/select")
-def select_prompt(data: Dict[str, str], chat_name: str = "", global_prompt_name: str = ""):
-    memory_manager.update_paths(chat_name=chat_name, global_prompt_name=global_prompt_name)
+def select_prompt(
+    data: Dict[str, str], chat_name: str = "", global_prompt_name: str = ""
+):
+    memory_manager.update_paths(
+        chat_name=chat_name, global_prompt_name=global_prompt_name
+    )
     """Set ``data['name']`` as the active system prompt."""
 
     name = data.get("name", "").strip()
@@ -165,7 +185,9 @@ def select_prompt(data: Dict[str, str], chat_name: str = "", global_prompt_name:
 @settings_router.get("/")
 def load_settings_endpoint(chat_name: str = "", global_prompt_name: str = ""):
     """Return the current server settings."""
-    memory_manager.update_paths(chat_name=chat_name, global_prompt_name=global_prompt_name)
+    memory_manager.update_paths(
+        chat_name=chat_name, global_prompt_name=global_prompt_name
+    )
     return memory_manager.load_settings()
 
 
@@ -173,7 +195,9 @@ def load_settings_endpoint(chat_name: str = "", global_prompt_name: str = ""):
 def update_settings_endpoint(
     data: Dict[str, object], chat_name: str = "", global_prompt_name: str = ""
 ):
-    memory_manager.update_paths(chat_name=chat_name, global_prompt_name=global_prompt_name)
+    memory_manager.update_paths(
+        chat_name=chat_name, global_prompt_name=global_prompt_name
+    )
     updated = memory_manager.update_settings(data)
     return {"detail": "Updated", "settings": updated}
 
@@ -183,7 +207,9 @@ def update_settings_endpoint(
 
 @app.get("/response_prompt_status")
 def response_prompt_status(chat_name: str = "", global_prompt_name: str = ""):
-    memory_manager.update_paths(chat_name=chat_name, global_prompt_name=global_prompt_name)
+    memory_manager.update_paths(
+        chat_name=chat_name, global_prompt_name=global_prompt_name
+    )
     return {"pending": 0}
 
 
@@ -192,7 +218,9 @@ def response_prompt_status(chat_name: str = "", global_prompt_name: str = ""):
 
 @chat_router.get("/")
 def list_chats(chat_name: str = "", global_prompt_name: str = ""):
-    memory_manager.update_paths(chat_name=chat_name, global_prompt_name=global_prompt_name)
+    memory_manager.update_paths(
+        chat_name=chat_name, global_prompt_name=global_prompt_name
+    )
     return {"chats": memory_manager.list_chats()}
 
 
@@ -205,54 +233,58 @@ def create_chat(
     """Create an empty chat directory for ``chat_name``."""
     if chat_name in memory_manager.list_chats():
         raise HTTPException(status_code=400, detail="Chat already exists")
-    memory_manager.save_history(chat_name, [])
+    memory_manager.save_chat_history(chat_name, [])
     memory.toggle_goals(False)
     memory.update_paths(chat_name=chat_name, global_prompt_name=global_prompt_name)
     return {"detail": f"Created chat '{chat_name}'", "chat_name": chat_name}
 
 
-@chat_router.get("/{chat_name}/history")
-def load_history_endpoint(
+@chat_router.get("/{chat_name}/chat_history")
+def load_chat_history_endpoint(
     chat_name: str,
     memory: MemoryManager = Depends(get_memory_manager),
     global_prompt_name: str = "",
 ):
     memory.update_paths(chat_name=chat_name, global_prompt_name=global_prompt_name)
-    history_data = memory.load_history(chat_name)
+    chat_history_data = memory.load_chat_history(chat_name)
     memory.load_goals(chat_name)
-    return {"chat_name": chat_name, "history": history_data}
+    return {"chat_name": chat_name, "chat_history": chat_history_data}
 
 
-@chat_router.put("/{chat_name}/history/{index}")
+@chat_router.put("/{chat_name}/chat_history/{index}")
 def save_message_endpoint(
     chat_name: str,
     index: int,
     data: Dict[str, str],
     global_prompt_name: str = "",
 ):
-    """Persist edits to a specific message in history."""
-    memory_manager.update_paths(chat_name=chat_name, global_prompt_name=global_prompt_name)
-    full = memory_manager.load_history(chat_name)
+    """Persist edits to a specific message in chat_history."""
+    memory_manager.update_paths(
+        chat_name=chat_name, global_prompt_name=global_prompt_name
+    )
+    full = memory_manager.load_chat_history(chat_name)
     if index < 0 or index >= len(full):
         raise HTTPException(status_code=400, detail="Invalid index")
     full[index]["content"] = data.get("content", "")
-    memory_manager.save_history(chat_name, full)
+    memory_manager.save_chat_history(chat_name, full)
     return {"detail": "Updated"}
 
 
-@chat_router.delete("/{chat_name}/history/{index}")
+@chat_router.delete("/{chat_name}/chat_history/{index}")
 def delete_message_endpoint(
     chat_name: str,
     index: int,
     global_prompt_name: str = "",
 ):
-    """Remove the message at ``index`` from stored history."""
-    memory_manager.update_paths(chat_name=chat_name, global_prompt_name=global_prompt_name)
-    full = memory_manager.load_history(chat_name)
+    """Remove the message at ``index`` from stored chat_history."""
+    memory_manager.update_paths(
+        chat_name=chat_name, global_prompt_name=global_prompt_name
+    )
+    full = memory_manager.load_chat_history(chat_name)
     if index < 0 or index >= len(full):
         raise HTTPException(status_code=400, detail="Invalid index")
     full.pop(index)
-    memory_manager.save_history(chat_name, full)
+    memory_manager.save_chat_history(chat_name, full)
     return {"detail": "Deleted"}
 
 
@@ -261,7 +293,7 @@ def delete_chat(
     chat_name: str,
     global_prompt_name: str = "",
 ):
-    """Erase all history for ``chat_name``."""
+    """Erase all chat_history for ``chat_name``."""
     memory_manager.delete_chat(chat_name)
     memory_manager.update_paths(chat_name="", global_prompt_name=global_prompt_name)
     return {"detail": f"Deleted chat '{chat_name}'"}
@@ -400,10 +432,12 @@ def save_context_file(
 def run_cli_command(chat_name: str, req: ChatRequest):
     """Execute a shell command and stream its output."""
 
-    memory_manager.update_paths(chat_name=chat_name, global_prompt_name=req.global_prompt_name)
-    history = memory_manager.load_history(chat_name)
-    history.append({"role": "user", "content": req.message})
-    memory_manager.save_history(chat_name, history)
+    memory_manager.update_paths(
+        chat_name=chat_name, global_prompt_name=req.global_prompt_name
+    )
+    chat_history = memory_manager.load_chat_history(chat_name)
+    chat_history.append({"role": "user", "content": req.message})
+    memory_manager.save_chat_history(chat_name, chat_history)
     prepared = PromptPreparer().prepare("", req.message)
     stream = LLMInvoker().invoke(prepared, {"stream": True})
 
@@ -413,9 +447,9 @@ def run_cli_command(chat_name: str, req: ChatRequest):
             text = chunk.get("text", "")
             parts.append(text)
             yield text
-        history = memory_manager.load_history(chat_name)
-        history.append({"role": "assistant", "content": "".join(parts)})
-        memory_manager.save_history(chat_name, history)
+        chat_history = memory_manager.load_chat_history(chat_name)
+        chat_history.append({"role": "assistant", "content": "".join(parts)})
+        memory_manager.save_chat_history(chat_name, chat_history)
 
     return StreamingResponse(_generate(), media_type="text/plain")
 
@@ -424,10 +458,12 @@ def run_cli_command(chat_name: str, req: ChatRequest):
 def chat_message(chat_name: str, req: ChatRequest):
     """Process a user message and stream the assistant reply."""
 
-    memory_manager.update_paths(chat_name=chat_name, global_prompt_name=req.global_prompt_name or "")
-    history = memory_manager.load_history(chat_name)
-    history.append({"role": "user", "content": req.message})
-    memory_manager.save_history(chat_name, history)
+    memory_manager.update_paths(
+        chat_name=chat_name, global_prompt_name=req.global_prompt_name or ""
+    )
+    chat_history = memory_manager.load_chat_history(chat_name)
+    chat_history.append({"role": "user", "content": req.message})
+    memory_manager.save_chat_history(chat_name, chat_history)
     global_prompt = memory_manager.get_global_prompt(req.global_prompt_name or "")
     return handle_chat(
         chat_name,
@@ -447,11 +483,12 @@ def send_chat(req: SendChatRequest):
     memory_manager.chat_name = req.chat_name or ""
     memory_manager.global_prompt_name = req.global_prompt_name or ""
     memory_manager.update_paths(
-        chat_name=memory_manager.chat_name, global_prompt_name=memory_manager.global_prompt_name
+        chat_name=memory_manager.chat_name,
+        global_prompt_name=memory_manager.global_prompt_name,
     )
-    history = memory_manager.load_history(memory_manager.chat_name)
-    history.append({"role": "user", "content": req.message})
-    memory_manager.save_history(memory_manager.chat_name, history)
+    chat_history = memory_manager.load_chat_history(memory_manager.chat_name)
+    chat_history.append({"role": "user", "content": req.message})
+    memory_manager.save_chat_history(memory_manager.chat_name, chat_history)
     global_prompt = req.global_prompt or ""
     return handle_chat(
         memory_manager.chat_name,
@@ -471,10 +508,12 @@ def append_assistant_message(
 ):
     """Add an assistant response without calling the model."""
 
-    memory_manager.update_paths(chat_name=chat_name, global_prompt_name=req.global_prompt_name or "")
-    history = memory_manager.load_history(chat_name)
-    history.append({"role": "assistant", "content": req.message})
-    memory_manager.save_history(chat_name, history)
+    memory_manager.update_paths(
+        chat_name=chat_name, global_prompt_name=req.global_prompt_name or ""
+    )
+    chat_history = memory_manager.load_chat_history(chat_name)
+    chat_history.append({"role": "assistant", "content": req.message})
+    memory_manager.save_chat_history(chat_name, chat_history)
     return {"detail": "Appended"}
 
 
@@ -486,11 +525,15 @@ def append_user_message(req: ChatRequest):
     if not chat_name:
         raise HTTPException(status_code=400, detail="No active chat")
     memory_manager.chat_name = chat_name
-    memory_manager.global_prompt_name = req.global_prompt_name or memory_manager.global_prompt_name
-    memory_manager.update_paths(chat_name=chat_name, global_prompt_name=memory_manager.global_prompt_name)
-    history = memory_manager.load_history(chat_name)
-    history.append({"role": "user", "content": req.message})
-    memory_manager.save_history(chat_name, history)
+    memory_manager.global_prompt_name = (
+        req.global_prompt_name or memory_manager.global_prompt_name
+    )
+    memory_manager.update_paths(
+        chat_name=chat_name, global_prompt_name=memory_manager.global_prompt_name
+    )
+    chat_history = memory_manager.load_chat_history(chat_name)
+    chat_history.append({"role": "user", "content": req.message})
+    memory_manager.save_chat_history(chat_name, chat_history)
     return {"detail": "Message stored", "chat_name": chat_name}
 
 

--- a/mythforge/memory.py
+++ b/mythforge/memory.py
@@ -118,20 +118,22 @@ class MemoryManager:
         _save_json(path, data)
 
     # ------------------------------------------------------------------
-    # History helpers
+    # Chat history helpers
     # ------------------------------------------------------------------
-    def load_history(self, chat_name: str) -> List[Dict[str, Any]]:
-        """Retrieve message history for ``chat_name``."""
+    def load_chat_history(self, chat_name: str) -> List[Dict[str, Any]]:
+        """Retrieve message chat_history for ``chat_name``."""
 
         self.update_paths(chat_name=chat_name)
         return list(self._read_json(self._chat_file(chat_name, "full.json")))
 
-    def save_history(self, chat_name: str, history: List[Dict[str, Any]]) -> None:
-        """Persist ``history`` for ``chat_name``."""
+    def save_chat_history(
+        self, chat_name: str, chat_history: List[Dict[str, Any]]
+    ) -> None:
+        """Persist ``chat_history`` for ``chat_name``."""
 
         self._ensure_chat_dir(chat_name)
         self.update_paths(chat_name=chat_name)
-        self._write_json(self._chat_file(chat_name, "full.json"), history)
+        self._write_json(self._chat_file(chat_name, "full.json"), chat_history)
 
     def list_chats(self) -> List[str]:
         """Return a list of existing chat identifiers."""
@@ -340,7 +342,9 @@ class MemoryManager:
         """Write a new prompt file and mark it active."""
 
         os.makedirs(self.global_prompts_dir, exist_ok=True)
-        self._write_json(self._global_prompt_path(name), {"name": name, "content": content})
+        self._write_json(
+            self._global_prompt_path(name), {"name": name, "content": content}
+        )
         self.update_paths(global_prompt_name=name)
 
     def delete_global_prompt(self, name: str) -> None:

--- a/ui/MythForgeUI.html
+++ b/ui/MythForgeUI.html
@@ -19,12 +19,12 @@
         <div class="sidebar" id="sidebar">
             <div id="chat-section">
                 <button class="new-chat" id="new-chat-btn">New Chat</button>
-                <div class="history-container" id="history-container"></div>
+                <div class="chat_history-container" id="chat_history-container"></div>
             </div>
             <div id="prompt-section" style="display:none;">
                 <button class="new-chat" id="new-prompt-btn">New Prompt</button>
                 <button class="new-chat" id="no-prompt-btn">No Prompt</button>
-                <div class="history-container" id="prompt-list"></div>
+                <div class="chat_history-container" id="prompt-list"></div>
             </div>
             <div id="more-section" style="display:none;">
                 <button id="open-settings-btn" class="new-chat">Local Settings</button>

--- a/ui/script.js
+++ b/ui/script.js
@@ -61,7 +61,7 @@ let abortController    = null;
 let handleScroll       = null;
 let promptCheckTimer   = null;
 const newChatButton    = document.getElementById('new-chat-btn');
-const historyContainer = document.getElementById('history-container');
+const chatHistoryContainer = document.getElementById('chat_history-container');
        const themeSelect      = document.getElementById('theme-select');
 const textSizeSelect  = document.getElementById('text-size-select');
 const newPromptBtn     = document.getElementById('new-prompt-btn');
@@ -377,7 +377,7 @@ function hideSidebar(){
 }
 
 function renderHistory(){
-    historyContainer.innerHTML = '';
+    chatHistoryContainer.innerHTML = '';
     state.chats.forEach(id => {
 const div = document.createElement('div');
 div.className = 'chat-history-item';
@@ -404,12 +404,12 @@ deleteBtn.onclick = (e)=>{ e.stopPropagation(); deleteChat(id); };
 div.appendChild(deleteBtn);
 
 div.onclick = () => loadChat(id);
-historyContainer.appendChild(div);
+chatHistoryContainer.appendChild(div);
     });
 }
 
 function updateActiveChat(){
-    const items = historyContainer.querySelectorAll('.chat-history-item');
+    const items = chatHistoryContainer.querySelectorAll('.chat-history-item');
     items.forEach(div=>{
 const name = div.querySelector('.chat-name').textContent;
 if(name === state.currentChatName){
@@ -444,7 +444,7 @@ async function loadChat(id){
     state.globalPrompt='';
     systemToggle.style.display='none';
     try{
-const res = await apiFetch(`/chats/${encodeURIComponent(id)}/history`);
+const res = await apiFetch(`/chats/${encodeURIComponent(id)}/chat_history`);
 if(!res.ok) return;
 const data = await res.json();
 let msgs = data;
@@ -454,10 +454,10 @@ if(!Array.isArray(data)){
         localStorage.setItem('lastChatName', data.chat_name);
         updateActiveChat();
     }
-    msgs = data.history || [];
+    msgs = data.chat_history || [];
 }
 msgs.forEach(m => appendMessageToUI(m.role==='bot'?'assistant':m.role, m.content));
-    }catch(e){ console.error('Failed to load history:',e); }
+    }catch(e){ console.error('Failed to load chat_history:',e); }
 }
 
 function renderPromptList(){
@@ -755,7 +755,7 @@ function closeMessageMenu(){ if(activeMenu){ activeMenu.remove(); activeMenu=nul
 async function editMessage(index, current){
     promptTextarea('Edit message:', current, async (text)=>{
 try{
-    const res = await apiFetch(`/chats/${encodeURIComponent(state.currentChatName)}/history/${index}`, {
+    const res = await apiFetch(`/chats/${encodeURIComponent(state.currentChatName)}/chat_history/${index}`, {
         method:'PUT',
         headers:{'Content-Type':'application/json'},
         body: JSON.stringify({content:text})
@@ -769,7 +769,7 @@ try{
 async function deleteMessage(index){
     confirmDialog('Delete this message?', async ()=>{
 try{
-    const res = await apiFetch(`/chats/${encodeURIComponent(state.currentChatName)}/history/${index}`, {method:'DELETE'});
+    const res = await apiFetch(`/chats/${encodeURIComponent(state.currentChatName)}/chat_history/${index}`, {method:'DELETE'});
     if(!res.ok){ const j=await res.json(); throw new Error(j.detail||'Server error'); }
     await loadChat(state.currentChatName);
 }catch(e){ alert('Failed to delete: '+e.message); }

--- a/ui/style.css
+++ b/ui/style.css
@@ -105,7 +105,7 @@ body {
 .sidebar button:hover { background-color: var(--sidebar-btn-hover); }
 .sidebar button.active { background-color: var(--sidebar-btn-hover); }
 .sidebar button.new-chat { padding: 12px; text-align: left; margin-bottom: 20px; display: flex; align-items: center; }
-.history-container { flex-grow: 1; overflow-y: auto; }
+.chat_history-container { flex-grow: 1; overflow-y: auto; }
 .chat-history-item {
     width: 100%;
     box-sizing: border-box;


### PR DESCRIPTION
## Summary
- rename load_history/save_history methods to load_chat_history/save_chat_history
- rename history endpoint and related variables
- update UI references to use chat_history instead of history

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68507e3abb24832b9d4a33dc50ddb23a