### PR TITLE
Fix leftover call to old goal helper

### DIFF
--- a/mythforge/call_core.py
+++ b/mythforge/call_core.py
@@ -148,7 +148,7 @@ def _finalize_chat(
     chat_history = memory.load_chat_history(chat_name)
     chat_history.append({"role": "assistant", "content": reply})
     memory.save_chat_history(chat_name, chat_history)
-    _maybe_generate_goals(chat_name, global_prompt, memory)
+    evaluate_goals(chat_name, global_prompt, memory)
 
 
 def handle_chat(


### PR DESCRIPTION
## Summary
- call `evaluate_goals` after each chat turn

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_6850829d9fdc832b9e22792f9a17ba82