### PR TITLE
Drop unused current_chat_name parameter

### DIFF
--- a/mythforge/call_core.py
+++ b/mythforge/call_core.py
@@ -160,7 +160,6 @@ def handle_chat(
     memory: MemoryManager = MEMORY_MANAGER,
     stream: bool = False,
     *,
-    current_chat_name: str | None = None,
     current_global_prompt: str | None = None,
 ):
     """Orchestrate a full chat cycle and persist the result."""
@@ -169,13 +168,12 @@ def handle_chat(
         "chat_flow",
         {
             "function": "handle_chat",
-            "chat_name": current_chat_name or chat_name,
+            "chat_name": chat_name,
             "message": message,
             "global_prompt": global_prompt,
             "call_type": call_type,
             "options": options,
             "stream": stream,
-            "current_chat_name": current_chat_name,
             "current_global_prompt": current_global_prompt,
             "memory_root": memory.root_dir,
         },

--- a/mythforge/main.py
+++ b/mythforge/main.py
@@ -471,7 +471,6 @@ def chat_message(chat_name: str, req: ChatRequest):
         global_prompt,
         memory=memory_manager,
         stream=True,
-        current_chat_name=chat_name,
         current_global_prompt=req.global_prompt_name,
     )
 
@@ -502,7 +501,6 @@ def send_chat(req: SendChatRequest):
         global_prompt,
         memory=memory_manager,
         stream=True,
-        current_chat_name=chat_name,
         current_global_prompt=global_prompt_name,
     )
 


### PR DESCRIPTION
## Summary
- streamline chat handling by removing `current_chat_name`

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68508e360078832b8470d03e0f6f6a57