### PR TITLE
Switch to chat-style prompts

### DIFF
--- a/mythforge/invoker.py
+++ b/mythforge/invoker.py
@@ -22,7 +22,9 @@ class LLMInvoker:
 
         self.config = config
 
-    def invoke(self, prompt: str, options: Dict[str, Any] | None = None):
+    def invoke(
+        self, prompt: str | list[dict[str, str]], options: Dict[str, Any] | None = None
+    ):
         """Send ``prompt`` to the model and return its output."""
 
         LOGGER.log(

--- a/mythforge/prompt_preparer.py
+++ b/mythforge/prompt_preparer.py
@@ -21,7 +21,7 @@ class PromptPreparer:
         user_text: str = "",
         *,
         name: str | None = None,
-    ) -> str:
+    ) -> list[dict[str, str]]:
         """Return a full prompt for ``system_text`` and ``user_text``.
 
         If ``name`` is provided, ``system_text`` will be loaded from the
@@ -51,20 +51,13 @@ class PromptPreparer:
             user_text.replace("\n", " ").replace('"', '\\"').strip()
         )
 
-        # Construct the prompt according to Llama 3 chat format
-        prompt_full = [f"<|begin_of_text|>"]
+        prompt_full: list[dict[str, str]] = []
 
         if system_text_clean:
-            prompt_full.append(
-                f"<|start_header_id|>system<|end_header_id|>\n"
-                f"{system_text_clean}<|eot_id|>"
-            )
+            prompt_full.append({"role": "system", "content": system_text_clean})
 
-        prompt_full.append(
-            f"<|start_header_id|>user<|end_header_id|>\n"
-            f"{user_text_clean}<|eot_id|>"
-        )
+        prompt_full.append({"role": "user", "content": user_text_clean})
 
-        prompt_full.append(f"<|start_header_id|>assistant<|end_header_id|>\n")
+        prompt_full.append({"role": "assistant", "content": ""})
 
-        return "".join(prompt_full)
+        return prompt_full

--- a/mythforge/response_parser.py
+++ b/mythforge/response_parser.py
@@ -48,15 +48,33 @@ class ResponseParser:
 
             def _iter() -> Iterator[str]:
                 for chunk in self.raw:
-                    if isinstance(chunk, dict) and "text" in chunk:
-                        yield str(chunk["text"])
+                    if isinstance(chunk, dict):
+                        if "text" in chunk:
+                            yield str(chunk["text"])
+                        elif "choices" in chunk:
+                            choice = chunk.get("choices", [{}])[0]
+                            delta = choice.get("delta", {})
+                            if "content" in delta:
+                                yield str(delta["content"])
+                            else:
+                                message = choice.get("message", {})
+                                yield str(message.get("content", ""))
+                        else:
+                            yield str(chunk)
                     else:
                         yield str(chunk)
 
             return _iter()
 
-        if isinstance(self.raw, dict) and "text" in self.raw:
-            text = str(self.raw["text"])
+        if isinstance(self.raw, dict):
+            if "text" in self.raw:
+                text = str(self.raw["text"])
+            elif "choices" in self.raw:
+                choice = self.raw.get("choices", [{}])[0]
+                message = choice.get("message", {})
+                text = str(message.get("content", ""))
+            else:
+                text = str(self.raw)
         else:
             text = str(self.raw)
 


### PR DESCRIPTION
## Summary
- update PromptPreparer to return a list of message dictionaries
- allow LLMInvoker and model.call_llm to handle chat style prompts
- extend ResponseParser to parse chat completion output

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68509a30ab8c832b9909e131d7ae11be