### PR TITLE
Fix model arg pass-through

### DIFF
--- a/mythforge/model.py
+++ b/mythforge/model.py
@@ -113,6 +113,9 @@ def call_llm(prompt: str | list[dict[str, str]], **overrides):
     stream = params.pop("stream", True)
     verbose = params.pop("verbose", False)
     params.pop("n_gpu_layers", None)
+    params.pop("n_ctx", None)
+    params.pop("n_batch", None)
+    params.pop("n_threads", None)
 
     llm = _get_llama(background, verbose)
 


### PR DESCRIPTION
## Summary
- prevent unsupported params from being passed to `llama_cpp`

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_6850a140e064832bb64d99cacc4d9135