### PR TITLE
Refactor goals storage and prompt prep

### DIFF
--- a/mythforge/call_templates/standard_chat.py
+++ b/mythforge/call_templates/standard_chat.py
@@ -2,12 +2,13 @@ from __future__ import annotations
 
 """Prompt helpers for standard chat interactions."""
 
-from typing import Iterator, Dict, Any
+from typing import Iterator, Dict, Any, List
 
 from ..response_parser import ResponseParser
 from ..prompt_preparer import PromptPreparer
 from ..invoker import LLMInvoker
 from ..logger import LOGGER
+from ..memory import MemoryManager, MEMORY_MANAGER
 
 
 
@@ -16,6 +17,50 @@ MODEL_LAUNCH_OVERRIDE: Dict[str, Any] = {
     "stream": True,
     "verbose": True,
 }
+
+
+def standard_chat_prepared_system_text(
+    chat_name: str,
+    global_prompt: str,
+    memory: MemoryManager = MEMORY_MANAGER,
+) -> str:
+    """Compose the system prompt for standard chat."""
+
+    memory.update_paths(chat_name=chat_name)
+    goals = memory.load_goals(chat_name)
+    parts: List[str] = [global_prompt]
+
+    if memory.goals_active:
+        if goals.character:
+            parts.append(goals.character)
+        if goals.setting:
+            parts.append(goals.setting)
+        state = memory.load_goal_state(chat_name)
+        active = state.get("goals", [])
+        if active:
+            goal_lines = ["Active goals:"]
+            for item in active:
+                if isinstance(item, dict):
+                    goal_lines.append(f"- {item.get('description', '')}")
+                else:
+                    goal_lines.append(f"- {item}")
+            parts.append("\n".join(goal_lines))
+
+    return "\n".join(p for p in parts if p)
+
+
+def standard_chat_prepared_user_text(
+    chat_name: str,
+    message: str,
+    memory: MemoryManager = MEMORY_MANAGER,
+) -> str:
+    """Combine chat history and the new message."""
+
+    history = memory.load_chat_history(chat_name)
+    history_text = "\n".join(m.get("content", "") for m in history)
+    if history_text:
+        return f"{history_text}\n{message}"
+    return message
 
 def standard_chat(
     chat_name: str,
@@ -37,7 +82,9 @@ def standard_chat(
         },
     )
 
-    prepared = PromptPreparer().prepare(global_prompt, message)
+    system_text = standard_chat_prepared_system_text(chat_name, global_prompt)
+    user_text = standard_chat_prepared_user_text(chat_name, message)
+    prepared = PromptPreparer().prepare(system_text, user_text)
     opts = {**MODEL_LAUNCH_OVERRIDE, **options}
     raw = LLMInvoker().invoke(prepared, opts)
     return ResponseParser().load(raw).parse()

--- a/mythforge/main.py
+++ b/mythforge/main.py
@@ -332,12 +332,13 @@ def get_goals(
     """Load current goals associated with ``chat_name``."""
     memory.update_paths(chat_name=chat_name, global_prompt_name=global_prompt_name)
     goals = memory.load_goals(chat_name)
+    state = memory.load_goal_state(chat_name)
     return {
         "exists": memory.goals_active,
         "character": goals.character,
         "setting": goals.setting,
-        "in_progress": goals.active_goals,
-        "completed": goals.deactive_goals,
+        "in_progress": state.get("goals", []),
+        "completed": state.get("completed_goals", []),
     }
 
 
@@ -352,6 +353,12 @@ def save_goals(
 
     memory.update_paths(chat_name=chat_name, global_prompt_name=global_prompt_name)
     memory.save_goals(chat_name, data)
+    state = memory.load_goal_state(chat_name)
+    if "in_progress" in data:
+        state["goals"] = data.get("in_progress", [])
+    if "completed" in data:
+        state["completed_goals"] = data.get("completed", [])
+    memory.save_goal_state(chat_name, state)
     return {"detail": "Saved"}
 
 
@@ -420,10 +427,6 @@ def save_context_file(
         "setting": data.get("setting", ""),
     }
     memory.update_paths(chat_name=chat_name, global_prompt_name=global_prompt_name)
-    existing = memory.load_goals(chat_name)
-    if existing.active_goals or existing.deactive_goals:
-        obj["in_progress"] = existing.active_goals
-        obj["completed"] = existing.deactive_goals
     memory.save_goals(chat_name, obj)
     return {"detail": "Saved"}
 

--- a/mythforge/memory.py
+++ b/mythforge/memory.py
@@ -300,12 +300,16 @@ class MemoryManager:
         except Exception:
             self.toggle_goals(False)
             return GoalsData()
+
         self.toggle_goals(True)
+
+        state = self.load_goal_state(name)
+
         return GoalsData(
             character=str(data.get("character", "")),
             setting=str(data.get("setting", "")),
-            active_goals=list(data.get("in_progress", [])),
-            deactive_goals=list(data.get("completed", [])),
+            active_goals=list(state.get("goals", [])),
+            deactive_goals=list(state.get("completed_goals", [])),
         )
 
     def save_goals(self, chat_name: str, data: Dict[str, Any]) -> None:
@@ -316,8 +320,6 @@ class MemoryManager:
         obj = {
             "character": data.get("character", ""),
             "setting": data.get("setting", ""),
-            "in_progress": data.get("in_progress", []),
-            "completed": data.get("completed", []),
         }
         self._write_json(self._goals_path(chat_name), obj)
         self.toggle_goals(True)


### PR DESCRIPTION
## Summary
- drop goal lists from goals.json
- pull active goals from `goal_state.json`
- adjust context save endpoint
- prepare standard chat prompts with helpers

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6850a42ba1a8832bb16be960c1617cdf