### PR TITLE
Refactor goal tracking and chat prep

### DIFF
--- a/mythforge/main.py
+++ b/mythforge/main.py
@@ -332,12 +332,13 @@ def get_goals(
     """Load current goals associated with ``chat_name``."""
     memory.update_paths(chat_name=chat_name, global_prompt_name=global_prompt_name)
     goals = memory.load_goals(chat_name)
+    state = memory.load_goal_state(chat_name)
     return {
         "exists": memory.goals_active,
         "character": goals.character,
         "setting": goals.setting,
-        "in_progress": goals.active_goals,
-        "completed": goals.deactive_goals,
+        "in_progress": state.get("goals", []),
+        "completed": state.get("completed_goals", []),
     }
 
 
@@ -420,10 +421,6 @@ def save_context_file(
         "setting": data.get("setting", ""),
     }
     memory.update_paths(chat_name=chat_name, global_prompt_name=global_prompt_name)
-    existing = memory.load_goals(chat_name)
-    if existing.active_goals or existing.deactive_goals:
-        obj["in_progress"] = existing.active_goals
-        obj["completed"] = existing.deactive_goals
     memory.save_goals(chat_name, obj)
     return {"detail": "Saved"}
 

--- a/mythforge/memory.py
+++ b/mythforge/memory.py
@@ -47,8 +47,6 @@ class GoalsData:
 
     character: str = ""
     setting: str = ""
-    active_goals: List[Any] = field(default_factory=list)
-    deactive_goals: List[Any] = field(default_factory=list)
     enabled: bool = False
 
 
@@ -304,8 +302,6 @@ class MemoryManager:
         return GoalsData(
             character=str(data.get("character", "")),
             setting=str(data.get("setting", "")),
-            active_goals=list(data.get("in_progress", [])),
-            deactive_goals=list(data.get("completed", [])),
         )
 
     def save_goals(self, chat_name: str, data: Dict[str, Any]) -> None:
@@ -316,8 +312,6 @@ class MemoryManager:
         obj = {
             "character": data.get("character", ""),
             "setting": data.get("setting", ""),
-            "in_progress": data.get("in_progress", []),
-            "completed": data.get("completed", []),
         }
         self._write_json(self._goals_path(chat_name), obj)
         self.toggle_goals(True)


### PR DESCRIPTION
## Summary
- simplify `GoalsData` to exclude goal lists
- update goal loading/saving to drop `in_progress` and `completed`
- fetch active goals from `goal_state` in the goals endpoint
- remove unused goal fields when saving context
- compose system and user text in standard chat with new helper functions

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6850a42ba1a8832bb16be960c1617cdf