### PR TITLE
Add formatted prompt logging

### DIFF
--- a/mythforge/call_core.py
+++ b/mythforge/call_core.py
@@ -88,13 +88,11 @@ Do not include any explanation, commentary, or other text. If no goals are curre
     system_parts.append(textwrap.dedent(goal_prompt).strip())
     system_text = "\n".join(system_parts)
 
+    preparer = PromptPreparer()
+    prompt_log = preparer.format_for_logging(system_text, user_text)
     LOGGER.log(
         "prepared_prompts",
-        {
-            "call_type": "goal_generation",
-            "system_text": system_text,
-            "user_text": user_text,
-        },
+        {"call_type": "goal_generation", "prompt": prompt_log},
     )
 
     from .call_templates import generate_goals

--- a/mythforge/call_templates/logic_goblin_evaluate_goals.py
+++ b/mythforge/call_templates/logic_goblin_evaluate_goals.py
@@ -7,6 +7,7 @@ from typing import Any, Dict, Iterator
 from ..prompt_preparer import PromptPreparer
 from ..response_parser import ResponseParser
 from ..invoker import LLMInvoker
+from ..logger import LOGGER
 
 MODEL_LAUNCH_OVERRIDE: Dict[str, Any] = {
     "background": True,
@@ -55,7 +56,14 @@ def logic_goblin_evaluate_goals(
     )
     system_text = logic_goblin_evaluate_goals_prepared_system_text(active_goals)
 
-    prepared = PromptPreparer().prepare(system_text, user_text)
+    preparer = PromptPreparer()
+    prompt_log = preparer.format_for_logging(system_text, user_text)
+    LOGGER.log(
+        "prepared_prompts",
+        {"call_type": "logic_goblin", "prompt": prompt_log},
+    )
+
+    prepared = preparer.prepare(system_text, user_text)
     opts = {**MODEL_LAUNCH_OVERRIDE, **options}
     raw = LLMInvoker().invoke(prepared, opts)
     return ResponseParser().load(raw).parse()

--- a/mythforge/call_templates/standard_chat.py
+++ b/mythforge/call_templates/standard_chat.py
@@ -84,7 +84,15 @@ def standard_chat(
 
     system_text = standard_chat_prepared_system_text(chat_name, global_prompt)
     user_text = standard_chat_prepared_user_text(chat_name, message)
-    prepared = PromptPreparer().prepare(system_text, user_text)
+
+    preparer = PromptPreparer()
+    prompt_log = preparer.format_for_logging(system_text, user_text)
+    LOGGER.log(
+        "prepared_prompts",
+        {"call_type": "standard_chat", "prompt": prompt_log},
+    )
+
+    prepared = preparer.prepare(system_text, user_text)
     opts = {**MODEL_LAUNCH_OVERRIDE, **options}
     raw = LLMInvoker().invoke(prepared, opts)
     return ResponseParser().load(raw).parse()

--- a/mythforge/prompt_preparer.py
+++ b/mythforge/prompt_preparer.py
@@ -61,3 +61,20 @@ class PromptPreparer:
         prompt_full.append({"role": "assistant", "content": ""})
 
         return prompt_full
+
+    def format_for_logging(self, system_text: str, user_text: str) -> str:
+        """Return ``system_text`` and ``user_text`` as a single log string."""
+
+        parts = [
+            "[system text]",
+            "",
+            system_text or "",
+            "",
+            "[user text]",
+            "",
+            user_text or "",
+            "",
+            "[assistant]",
+        ]
+
+        return "\n".join(parts)


### PR DESCRIPTION
## Summary
- log standardized prompt blocks in standard chats, logic goblin calls and goal generation
- support formatted logging via new `format_for_logging` helper

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6850a842df30832baf8a1ad3e1d03c82