### PR TITLE
Ensure main model persists

### DIFF
--- a/mythforge/background.py
+++ b/mythforge/background.py
@@ -6,7 +6,7 @@ import threading
 from queue import Queue, Empty
 from typing import Callable, Any, Tuple
 
-from .model import shutdown_llama
+from .model import shutdown_background_llama
 from .logger import LOGGER
 
 
@@ -26,7 +26,7 @@ def _worker() -> None:
             func(*args, **kwargs)
         finally:
             _TASK_QUEUE.task_done()
-    shutdown_llama()
+    shutdown_background_llama()
     LOGGER.log("background", {"event": "worker_exit"})
 
 


### PR DESCRIPTION
## Summary
- keep the primary model loaded across chats
- unload only background models when background queue is idle

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6850a953d934832bb7e25c2700ddfaf9