### PR TITLE
Improve prepared prompt log readability

### DIFF
--- a/mythforge/logger.py
+++ b/mythforge/logger.py
@@ -26,6 +26,13 @@ class LoggerManager:
         data = _load_json(path)
         if not isinstance(data, list):
             data = []
+        if event_type == "prepared_prompts" and isinstance(payload, dict):
+            text = payload.get("prompt")
+            if isinstance(text, str):
+                payload = {
+                    **payload,
+                    "prompt": text.splitlines(),
+                }
         data.insert(0, payload)
         _save_json(path, data)
 


### PR DESCRIPTION
## Summary
- split prepared prompt logs into lines

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- manual check of `server_logs/prepared_prompts.json`

------
https://chatgpt.com/codex/tasks/task_e_6850abe53a38832ba64258cc8e273349