### PR TITLE
Move goal evaluation to template module

### DIFF
--- a/mythforge/call_core.py
+++ b/mythforge/call_core.py
@@ -1,145 +1,18 @@
 from __future__ import annotations
 
-import textwrap
-from typing import Any, Dict, Iterable, Iterator, List
 import json
-
-from .model import GENERATION_CONFIG
+from typing import Any, Dict
 
 from fastapi.responses import StreamingResponse
 
-from .invoker import LLMInvoker
-from .prompt_preparer import PromptPreparer
-from .response_parser import ResponseParser, _parse_goals_from_response
 from .memory import MemoryManager, MEMORY_MANAGER
 from .logger import LOGGER
-from .background import schedule_task, has_pending_tasks
-
-
-# ---------------------------------------------------------------------------
-# Text helpers
-# ---------------------------------------------------------------------------
-
-
-def clean_text(text: str, *, trim: bool = False) -> str:
-    """Strip unwanted tokens and optionally trim whitespace."""
-
-    cleaned = text.replace("<|eot_id|>", "")
-    return cleaned.strip() if trim else cleaned
+from .call_templates.generate_goals import evaluate_goals
 
 
 # ---------------------------------------------------------------------------
 # Core chat handling
 # ---------------------------------------------------------------------------
-
-
-def _evaluate_goals(
-    chat_name: str,
-    global_prompt: str,
-    memory: MemoryManager = MEMORY_MANAGER,
-) -> None:
-    """Generate new goals when below the configured limit."""
-    LOGGER.log(
-        "chat_flow",
-        {
-            "function": "evaluate_goals",
-            "chat_name": chat_name,
-            "global_prompt": global_prompt,
-            "memory_root": memory.root_dir,
-        },
-    )
-    goals = memory.load_goals(chat_name)
-    if not memory.goals_active:
-        return
-    character = goals.character
-    setting = goals.setting
-
-    state = memory.load_goal_state(chat_name)
-    goal_limit = GENERATION_CONFIG.get("goal_limit", 3)
-    if len(state.get("goals", [])) >= goal_limit:
-        return
-
-    chat_history = memory.load_chat_history(chat_name)
-    user_text = "\n".join(m.get("content", "") for m in chat_history)
-
-    system_parts = [p for p in (global_prompt, character, setting) if p]
-
-    goal_prompt = f"""
-You are a reasoning assistant.
-
-Given the character profile and scene context, determine whether the character has any goals they would *naturally and strongly* pursue based on their personality, desires, or immediate situation.
-
-If so, generate up to {goal_limit} specific, actionable goals. For each goal, rate how much the character cares about it on a scale from 1 (barely cares) to 10 (deeply invested).
-
-ONLY respond in the following format:
-{{
-  "goals": [
-    {{
-      "description": "...",
-      "importance": 7
-    }},
-    ...
-  ]
-}}
-
-Do not include any explanation, commentary, or other text. If no goals are currently appropriate, return an empty list.
-"""
-
-    system_parts.append(textwrap.dedent(goal_prompt).strip())
-    system_text = "\n".join(system_parts)
-
-    preparer = PromptPreparer()
-    prompt_log = preparer.format_for_logging(system_text, user_text)
-    LOGGER.log(
-        "prepared_prompts",
-        {"call_type": "goal_generation", "prompt": prompt_log},
-    )
-
-    from .call_templates import generate_goals
-
-    try:
-        text = generate_goals.generate_goals(
-            system_text,
-            user_text,
-            {**generate_goals.MODEL_LAUNCH_OVERRIDE},
-        )
-    except Exception as exc:  # pragma: no cover - best effort
-        LOGGER.log_error(exc)
-        state["error"] = str(exc)
-        memory.save_goal_state(chat_name, state)
-        return
-
-    parsed = ResponseParser().load(text).parse()
-    if isinstance(parsed, Iterator):
-        parsed = "".join(parsed)
-    cleaned = clean_text(str(parsed), trim=True)
-    new_goals = _parse_goals_from_response(cleaned)
-
-    state.pop("error", None)
-    combined = state.get("goals", []) + new_goals
-    state["goals"] = combined[:goal_limit]
-    memory.save_goal_state(chat_name, state)
-
-
-def evaluate_goals(
-    chat_name: str,
-    global_prompt: str,
-    memory: MemoryManager = MEMORY_MANAGER,
-    *,
-    background: bool = True,
-) -> None:
-    """Schedule or run goal evaluation."""
-
-    if background:
-        schedule_task(_evaluate_goals, chat_name, global_prompt, memory)
-        return
-
-    _evaluate_goals(chat_name, global_prompt, memory)
-
-
-# ---------------------------------------------------------------------------
-
-
 def _finalize_chat(
     reply: str,
     chat_name: str,

--- a/mythforge/call_templates/generate_goals.py
+++ b/mythforge/call_templates/generate_goals.py
@@ -1,10 +1,15 @@
 from __future__ import annotations
 
+import textwrap
 from typing import Any, Dict, Iterator
 
-from ..response_parser import ResponseParser
+from ..response_parser import ResponseParser, _parse_goals_from_response
 from ..prompt_preparer import PromptPreparer
 from ..invoker import LLMInvoker
+from ..model import GENERATION_CONFIG
+from ..memory import MemoryManager, MEMORY_MANAGER
+from ..logger import LOGGER
+from ..background import schedule_task
 
 # -----------------------------------
 # Model launch parameters / arguments ORERRIDE
@@ -27,3 +32,112 @@ def generate_goals(
     opts = {**MODEL_LAUNCH_OVERRIDE, **options}
     raw = LLMInvoker().invoke(prepared, opts)
     return ResponseParser().load(raw).parse()
+
+
+def clean_text(text: str, *, trim: bool = False) -> str:
+    """Strip unwanted tokens and optionally trim whitespace."""
+
+    cleaned = text.replace("<|eot_id|>", "")
+    return cleaned.strip() if trim else cleaned
+
+
+def _evaluate_goals(
+    chat_name: str,
+    global_prompt: str,
+    memory: MemoryManager = MEMORY_MANAGER,
+) -> None:
+    """Generate new goals when below the configured limit."""
+    LOGGER.log(
+        "chat_flow",
+        {
+            "function": "evaluate_goals",
+            "chat_name": chat_name,
+            "global_prompt": global_prompt,
+            "memory_root": memory.root_dir,
+        },
+    )
+    goals = memory.load_goals(chat_name)
+    if not memory.goals_active:
+        return
+    character = goals.character
+    setting = goals.setting
+
+    state = memory.load_goal_state(chat_name)
+    goal_limit = GENERATION_CONFIG.get("goal_limit", 3)
+    if len(state.get("goals", [])) >= goal_limit:
+        return
+
+    chat_history = memory.load_chat_history(chat_name)
+    user_text = "\n".join(m.get("content", "") for m in chat_history)
+
+    system_parts = [p for p in (global_prompt, character, setting) if p]
+
+    goal_prompt = f"""
+You are a reasoning assistant.
+
+Given the character profile and scene context, determine whether the character has any goals they would *naturally and strongly* pursue based on their personality, desires, or immediate situation.
+
+If so, generate up to {goal_limit} specific, actionable goals. For each goal, rate how much the character cares about it on a scale from 1 (barely cares) to 10 (deeply invested).
+
+ONLY respond in the following format:
+{{
+  "goals": [
+    {{
+      "description": "...",
+      "importance": 7
+    }},
+    ...
+  ]
+}}
+
+Do not include any explanation, commentary, or other text. If no goals are currently appropriate, return an empty list.
+"""
+
+    system_parts.append(textwrap.dedent(goal_prompt).strip())
+    system_text = "\n".join(system_parts)
+
+    preparer = PromptPreparer()
+    prompt_log = preparer.format_for_logging(system_text, user_text)
+    LOGGER.log(
+        "prepared_prompts",
+        {"call_type": "goal_generation", "prompt": prompt_log},
+    )
+
+    try:
+        text = generate_goals(
+            system_text,
+            user_text,
+            {**MODEL_LAUNCH_OVERRIDE},
+        )
+    except Exception as exc:  # pragma: no cover - best effort
+        LOGGER.log_error(exc)
+        state["error"] = str(exc)
+        memory.save_goal_state(chat_name, state)
+        return
+
+    parsed = ResponseParser().load(text).parse()
+    if isinstance(parsed, Iterator):
+        parsed = "".join(parsed)
+    cleaned = clean_text(str(parsed), trim=True)
+    new_goals = _parse_goals_from_response(cleaned)
+
+    state.pop("error", None)
+    combined = state.get("goals", []) + new_goals
+    state["goals"] = combined[:goal_limit]
+    memory.save_goal_state(chat_name, state)
+
+
+def evaluate_goals(
+    chat_name: str,
+    global_prompt: str,
+    memory: MemoryManager = MEMORY_MANAGER,
+    *,
+    background: bool = True,
+) -> None:
+    """Schedule or run goal evaluation."""
+
+    if background:
+        schedule_task(_evaluate_goals, chat_name, global_prompt, memory)
+        return
+
+    _evaluate_goals(chat_name, global_prompt, memory)


### PR DESCRIPTION
## Summary
- relocate `_evaluate_goals` and `evaluate_goals` from `call_core` to `call_templates/generate_goals`
- update imports in `call_core` to reference the new location
- clean up unused helpers

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6850af59fd04832b8402e37a08e002ca