### PR TITLE
Add duplicate goal detection

### DIFF
--- a/mythforge/call_templates/logic_goblin_duplicate_goals.py
+++ b/mythforge/call_templates/logic_goblin_duplicate_goals.py
@@ -1,0 +1,78 @@
+from __future__ import annotations
+
+"""Prompt helpers for detecting duplicate goals."""
+
+from typing import Any, Dict, Iterator
+
+from ..prompt_preparer import PromptPreparer
+from ..response_parser import ResponseParser
+from ..invoker import LLMInvoker
+from ..logger import LOGGER
+
+MODEL_LAUNCH_OVERRIDE: Dict[str, Any] = {
+    "background": True,
+    "n_ctx": 4096,
+    "stream": False,
+    "max_tokens": 256,
+    "verbose": True,
+}
+
+
+# CallType helpers -----------------------------------------------------------
+
+def logic_goblin_duplicate_goals_prepared_user_text(goals: str) -> str:
+    """Compose the user prompt for duplicate goal detection."""
+
+    return "\n".join([
+        "Goals:",
+        goals,
+    ])
+
+
+def logic_goblin_duplicate_goals_prepared_system_text() -> str:
+    """Return the instruction text for duplicate goal detection."""
+
+    return """
+You are a logic goblin who detects duplicate or near-duplicate goals.
+
+Your task is to examine a list of character goals and determine if any of them are meaningfully the same—either by intent, action, or outcome.
+
+A goal is a duplicate if:
+- It shares the same purpose or outcome.
+- It could reasonably be merged with another goal without losing meaning.
+
+Output a JSON object listing any pairs of duplicate goal indices. If none are duplicates, return an empty list.
+
+Only respond in the following format:
+{
+  "duplicates": [[0, 2], [1, 3]]
+}
+(Where each pair refers to duplicate goals at those indices in the input list.)
+
+Do not add commentary or explanation.
+"""
+
+
+def logic_goblin_duplicate_goals(
+    global_prompt: str,
+    message: str,
+    options: Dict[str, Any],
+    *,
+    goals: str = "",
+) -> Iterator[str]:
+    """Send ``message`` through the duplicate-goal check prompt."""
+
+    user_text = logic_goblin_duplicate_goals_prepared_user_text(goals)
+    system_text = logic_goblin_duplicate_goals_prepared_system_text()
+
+    preparer = PromptPreparer()
+    prompt_log = preparer.format_for_logging(system_text, user_text)
+    LOGGER.log(
+        "prepared_prompts",
+        {"call_type": "logic_goblin", "prompt": prompt_log},
+    )
+
+    prepared = preparer.prepare(system_text, user_text)
+    opts = {**MODEL_LAUNCH_OVERRIDE, **options}
+    raw = LLMInvoker().invoke(prepared, opts)
+    return ResponseParser().load(raw).parse()


### PR DESCRIPTION
## Summary
- introduce logic_goblin_duplicate_goals call template for detecting duplicate goals
- invoke duplicate check when generating new goals

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6850b78682c4832bab6868706c217639