### PR TITLE
Add parsing and logging for goblin utilities

### DIFF
--- a/mythforge/call_templates/generate_goals.py
+++ b/mythforge/call_templates/generate_goals.py
@@ -48,7 +48,20 @@ def logic_goblin_duplicate_goals_call(goals: List[Any]) -> None:
 
     goals_json = json.dumps(goals, ensure_ascii=False, indent=2)
     try:
-        logic_goblin_duplicate_goals("", "", {**MODEL_LAUNCH_OVERRIDE}, goals=goals_json)
+        result_iter = logic_goblin_duplicate_goals(
+            "",
+            "",
+            {**MODEL_LAUNCH_OVERRIDE},
+            goals=goals_json,
+        )
+        result_text = "".join(list(result_iter))
+        LOGGER.log(
+            "chat_flow",
+            {
+                "function": "logic_goblin_duplicate_goals_call",
+                "output": result_text,
+            },
+        )
     except Exception as exc:  # pragma: no cover - best effort
         LOGGER.log_error(exc)
 


### PR DESCRIPTION
## Summary
- parse goblin results in `logic_goblin_evaluate_goals` and `logic_goblin_duplicate_goals`
- log goblin outputs from `logic_goblin_duplicate_goals_call`
- expose parsing helpers `_parse_goal_status_from_response` and `_parse_duplicates_from_response`

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6850baee74a4832ba33d4b7ab4a73e66