### PR TITLE
Fix duplicate goal handling and clean up chat helpers

### DIFF
--- a/mythforge/call_templates/standard_chat.py
+++ b/mythforge/call_templates/standard_chat.py
@@ -49,14 +49,6 @@ def standard_chat_prepared_system_text(
     return "\n".join(p for p in parts if p)
 
 
-def standered_chat_prepared_system_text(
-    chat_name: str,
-    global_prompt: str,
-    memory: MemoryManager = MEMORY_MANAGER,
-) -> str:
-    """Alias for :func:`standard_chat_prepared_system_text`."""
-
-    return standard_chat_prepared_system_text(chat_name, global_prompt, memory)
 
 
 def standard_chat_prepared_user_text(
@@ -73,14 +65,6 @@ def standard_chat_prepared_user_text(
     return message
 
 
-def standered_chat_prepared_user_text(
-    chat_name: str,
-    message: str,
-    memory: MemoryManager = MEMORY_MANAGER,
-) -> str:
-    """Alias for :func:`standard_chat_prepared_user_text`."""
-
-    return standard_chat_prepared_user_text(chat_name, message, memory)
 
 def standard_chat(
     chat_name: str,


### PR DESCRIPTION
## Summary
- remove unused `stendered_chat_*` helper functions
- parse duplicate-goal logic goblin output to drop repeats when generating goals

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6850bc24a9a4832b99819f64f4370344