### PR TITLE
Add temporary debug messages for goal changes

### DIFF
--- a/mythforge/call_templates/generate_goals.py
+++ b/mythforge/call_templates/generate_goals.py
@@ -150,9 +150,19 @@ Do not include any explanation, commentary, or other text. If no goals are curre
         logic_goblin_duplicate_goals_call(state.get("goals", []) + new_goals)
 
     state.pop("error", None)
-    combined = state.get("goals", []) + new_goals
+    previous = list(state.get("goals", []))
+    combined = previous + new_goals
     state["goals"] = combined[:goal_limit]
     memory.save_goal_state(chat_name, state)
+
+    for goal in new_goals:
+        desc = goal.get("description", str(goal))
+        memory.add_debug_message(f"new goal: {desc}")
+
+    removed = combined[goal_limit:]
+    for goal in removed:
+        desc = goal.get("description", str(goal))
+        memory.add_debug_message(f"goal removed: {desc}")
 
 
 def evaluate_goals(

--- a/mythforge/main.py
+++ b/mythforge/main.py
@@ -212,7 +212,8 @@ def response_prompt_status(chat_name: str = "", global_prompt_name: str = ""):
     )
     from .background import has_pending_tasks
 
-    return {"pending": int(has_pending_tasks())}
+    debug = memory_manager.pop_debug_messages()
+    return {"pending": int(has_pending_tasks()), "debug": debug}
 
 
 # --- Standard Chat Endpoints ---------------------------------------------

--- a/mythforge/memory.py
+++ b/mythforge/memory.py
@@ -71,6 +71,7 @@ class MemoryManager:
         self.chat_name: str = ""
         self.global_prompt_name: str = ""
         self.goals_active: bool = False
+        self._debug_messages: List[str] = []
 
     # ------------------------------------------------------------------
     # Path helpers
@@ -153,6 +154,21 @@ class MemoryManager:
             for fname in os.listdir(chat_dir):
                 os.remove(os.path.join(chat_dir, fname))
             os.rmdir(chat_dir)
+
+    # ------------------------------------------------------------------
+    # Debug helpers
+    # ------------------------------------------------------------------
+    def add_debug_message(self, message: str) -> None:
+        """Store ``message`` for the next status poll."""
+
+        self._debug_messages.append(message)
+
+    def pop_debug_messages(self) -> List[str]:
+        """Return and clear any pending debug messages."""
+
+        messages = self._debug_messages[:]
+        self._debug_messages.clear()
+        return messages
 
     def rename_chat(self, old_id: str, new_id: str) -> None:
         """Rename a chat folder from ``old_id`` to ``new_id``."""

--- a/ui/script.js
+++ b/ui/script.js
@@ -794,13 +794,22 @@ function showMessageMenu(div){
     setTimeout(()=>document.addEventListener('click', closeMessageMenu, {once:true}),0);
 }
 
-function appendMessageToUI(role, content){
+function appendMessageToUI(role, content, extraClass=''){ 
     const div=document.createElement('div');
-    div.className=`message ${role==='user'?'user-message':'ai-message'}`;
+    let base = 'message ';
+    if(role==='user') base += 'user-message';
+    else if(role==='assistant') base += 'ai-message';
+    else base += 'system-message';
+    if(extraClass) base += ' ' + extraClass;
+    div.className = base;
     div.dataset.index = chatContainer.children.length;
     const avatar=document.createElement('div');
-    avatar.className=`avatar ${role==='user'?'user-avatar':'ai-avatar'}`;
-    avatar.textContent = role==='user' ? (state.settings.userName[0]||'U') : (state.settings.botName[0]||'A');
+    if(role==='user') avatar.className='avatar user-avatar';
+    else if(role==='assistant') avatar.className='avatar ai-avatar';
+    else avatar.className='avatar system-avatar';
+    if(role==='user') avatar.textContent = (state.settings.userName[0]||'U');
+    else if(role==='assistant') avatar.textContent = (state.settings.botName[0]||'A');
+    else avatar.textContent = 'S';
     const contentDiv=document.createElement('div');
     contentDiv.className='message-content';
     contentDiv.innerHTML=content.replace(/\n/g,'<br>');
@@ -839,6 +848,9 @@ async function pollPromptStatus(){
 const res = await apiFetch('/response_prompt_status');
 if(res.ok){
     const data = await res.json();
+    if(Array.isArray(data.debug)){
+        data.debug.forEach(msg=>appendMessageToUI('system', msg, 'debug'));
+    }
     if(data.pending===0){
         state.isProcessing = false;
         updateBusyUI();

--- a/ui/style.css
+++ b/ui/style.css
@@ -146,6 +146,9 @@ body {
 .avatar { width: 30px; height: 30px; border-radius: 4px; display: flex; align-items: center; justify-content: center; margin-right: 15px; flex-shrink: 0; }
 .user-avatar { background-color: var(--user-msg-bg); color: var(--user-msg-color); }
 .ai-avatar { background-color: var(--primary); color: white; }
+.system-avatar { background-color: var(--border-color); color: var(--text-color); }
+.system-message { background-color: var(--chat-bg); }
+.debug-message { opacity: 0.7; font-style: italic; }
 .message-content { flex-grow: 1; max-width: none; line-height: 1.6; font-size: var(--message-font-size); }
 .message-control-btn { position: absolute; bottom: 4px; right: 4px; background: none; border: none; cursor: pointer; color: var(--text-color); display: none; }
 .message:hover .message-control-btn { display: block; }


### PR DESCRIPTION
## Summary
- store debug messages in `MemoryManager`
- surface debug messages via `/response_prompt_status`
- show debug messages in the UI without saving them
- style and support system/debug messages

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6850bf99eac0832bbdae2fe61482d9e0