### PR TITLE
Update worker timeout

### DIFF
--- a/mythforge/background.py
+++ b/mythforge/background.py
@@ -19,7 +19,7 @@ def _worker() -> None:
 
     while True:
         try:
-            func, args, kwargs = _TASK_QUEUE.get(timeout=5)
+            func, args, kwargs = _TASK_QUEUE.get(timeout=600)
         except Empty:
             break
         try:


### PR DESCRIPTION
## Summary
- extend background worker timeout from 5 seconds to 10 minutes

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6850c0548b78832b94a4943e404e190c