### PR TITLE
Fix goals enabling after rename

### DIFF
--- a/mythforge/memory.py
+++ b/mythforge/memory.py
@@ -236,6 +236,8 @@ class MemoryManager:
             }
             self._write_json(path, obj)
             os.remove(disabled)
+        elif not os.path.exists(path):
+            self._write_json(path, {"character": "", "setting": ""})
         self.load_goals(chat_name)
 
     # ------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- when enabling goals and no context file exists, create a blank file so renaming then enabling works

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6850d200d514832ba2cbd39c16b82690